### PR TITLE
Capture and log external networker's stderr

### DIFF
--- a/netplugin/external_networker.go
+++ b/netplugin/external_networker.go
@@ -66,6 +66,8 @@ func (p *ExternalBinaryNetworker) Network(log lager.Logger, containerSpec garden
 	cmd.Args = upArgs
 	cmdOutput := &bytes.Buffer{}
 	cmd.Stdout = cmdOutput
+	cmdStderr := &bytes.Buffer{}
+	cmd.Stderr = cmdStderr
 
 	input, err := cmd.StdinPipe()
 	if err != nil {
@@ -80,8 +82,11 @@ func (p *ExternalBinaryNetworker) Network(log lager.Logger, containerSpec garden
 
 	err = p.commandRunner.Run(cmd)
 	if err != nil {
+		log.Error("external-networker-result", err, lager.Data{"output": cmdStderr.String()})
 		return err
 	}
+
+	log.Info("external-networker-result", lager.Data{"output": cmdStderr.String()})
 
 	if len(cmdOutput.Bytes()) == 0 {
 		return nil


### PR DESCRIPTION
Similar to [#127923587](https://www.pivotaltracker.com/story/show/117043597) except the logs come on stderr now, since stdout is reserved for returning container properties.