### PR TITLE
Enhacements to support external networkers

### DIFF
--- a/gqt/net_test.go
+++ b/gqt/net_test.go
@@ -364,9 +364,8 @@ var _ = Describe("Networking", func() {
 				pluginReturn := `{"properties":{
 					"foo":"bar",
 					"kawasaki.mtu":"1499",
-					"garden.network.container-ip":"10.10.10.10",
-					"garden.network.host-ip":"11.11.11.11",
-					"garden.network.external-ip":"12.12.12.12"
+					"garden.network.container-ip":"10.255.10.10",
+					"garden.network.host-ip":"255.255.255.255"
 				}}`
 				args = append(args, "--network-plugin-extra-arg", pluginReturn)
 				extraProperties = garden.Properties{
@@ -374,13 +373,15 @@ var _ = Describe("Networking", func() {
 				}
 			})
 
-			It("persits the returned properties to the container's properties", func() {
+			It("persists the returned properties to the container's properties", func() {
 				info, err := container.Info()
 				Expect(err).NotTo(HaveOccurred())
 
 				containerProperties := info.Properties
 
 				Expect(containerProperties["foo"]).To(Equal("bar"))
+				Expect(containerProperties["garden.network.container-ip"]).To(Equal("10.255.10.10"))
+				Expect(containerProperties["garden.network.host-ip"]).To(Equal("255.255.255.255"))
 			})
 
 			It("doesn't remove existing properties", func() {
@@ -388,6 +389,14 @@ var _ = Describe("Networking", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(info.Properties).To(HaveKey("some-property-on-the-spec"))
+			})
+
+			It("sets the ExternalIP and ContainerIP fields on the container.Info()", func() {
+				info, err := container.Info()
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(info.ExternalIP).NotTo(BeEmpty())
+				Expect(info.ContainerIP).To(Equal("10.255.10.10"))
 			})
 		})
 	})

--- a/guardiancmd/command.go
+++ b/guardiancmd/command.go
@@ -380,7 +380,6 @@ func (cmd *GuardianCommand) wireNetworker(log lager.Logger, propManager kawasaki
 		externalNetworker := netplugin.New(
 			linux_command_runner.New(),
 			propManager,
-			portPool,
 			externalIP,
 			dnsServers,
 			resolvConfigurer,

--- a/kawasaki/networker.go
+++ b/kawasaki/networker.go
@@ -206,7 +206,7 @@ func (n *networker) NetIn(log lager.Logger, handle string, externalPort, contain
 		return 0, 0, err
 	}
 
-	if err := addPortMapping(log, n.configStore, handle, garden.PortMapping{
+	if err := AddPortMapping(log, n.configStore, handle, garden.PortMapping{
 		HostPort:      externalPort,
 		ContainerPort: containerPort,
 	}); err != nil {
@@ -289,7 +289,7 @@ func (n *networker) Restore(log lager.Logger, handle string) error {
 	return nil
 }
 
-func addPortMapping(logger lager.Logger, configStore ConfigStore, handle string, newMapping garden.PortMapping) error {
+func AddPortMapping(logger lager.Logger, configStore ConfigStore, handle string, newMapping garden.PortMapping) error {
 	var currentMappings portMappingList
 	if currentMappingsJson, ok := configStore.Get(handle, gardener.MappedPortsKey); ok {
 		var err error

--- a/netplugin/external_networker.go
+++ b/netplugin/external_networker.go
@@ -17,7 +17,6 @@ import (
 )
 
 const NetworkPropertyPrefix = "network."
-const NetOutKey = NetworkPropertyPrefix + "external-networker.net-out"
 
 type externalBinaryNetworker struct {
 	commandRunner    command_runner.CommandRunner


### PR DESCRIPTION
- `Network` sets ExternalIP property and configures DNS resolv conf
- `NetIn` allocates ports from port pool and persists them to the container's MappedPorts
- `NetOut` persists rules to a well-named container property, so that external components may discover the full set of rules

[Story #127325611](https://www.pivotaltracker.com/story/show/127325611)

cc @rosenhouse 
