### PR TITLE
Make rootfs and tarbin parameters to be passed in to guardian ifrit runner

### DIFF
--- a/gqt/gqt_suite_test.go
+++ b/gqt/gqt_suite_test.go
@@ -23,7 +23,7 @@ var defaultRuntime = map[string]string{
 
 var ginkgoIO = garden.ProcessIO{Stdout: GinkgoWriter, Stderr: GinkgoWriter}
 
-var ociRuntimeBin, gardenBin, initBin, nstarBin, dadooBin, inspectorGardenBin, testNetPluginBin string
+var ociRuntimeBin, gardenBin, initBin, nstarBin, dadooBin, inspectorGardenBin, testNetPluginBin, tarBin string
 
 func TestGqt(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -76,6 +76,8 @@ func TestGqt(t *testing.T) {
 		initBin = bins["init_bin_path"]
 		inspectorGardenBin = bins["inspector-garden_bin_path"]
 		testNetPluginBin = bins["test_net_plugin_bin_path"]
+
+		tarBin = os.Getenv("GARDEN_TAR_PATH")
 	})
 
 	BeforeEach(func() {
@@ -97,7 +99,8 @@ func TestGqt(t *testing.T) {
 }
 
 func startGarden(argv ...string) *runner.RunningGarden {
-	return runner.Start(gardenBin, initBin, nstarBin, dadooBin, true, argv...)
+	rootfs := os.Getenv("GARDEN_TEST_ROOTFS")
+	return runner.Start(gardenBin, initBin, nstarBin, dadooBin, rootfs, tarBin, argv...)
 }
 
 func restartGarden(client *runner.RunningGarden, argv ...string) {
@@ -107,5 +110,5 @@ func restartGarden(client *runner.RunningGarden, argv ...string) {
 }
 
 func startGardenWithoutDefaultRootfs(argv ...string) *runner.RunningGarden {
-	return runner.Start(gardenBin, initBin, nstarBin, dadooBin, false, argv...)
+	return runner.Start(gardenBin, initBin, nstarBin, dadooBin, "", tarBin, argv...)
 }

--- a/gqt/graph_test.go
+++ b/gqt/graph_test.go
@@ -152,7 +152,7 @@ var _ = Describe("graph flags", func() {
 
 			Context("and local images are used", func() {
 				BeforeEach(func() {
-					persistentImages = []string{runner.RootFSPath}
+					persistentImages = []string{os.Getenv("GARDEN_TEST_ROOTFS")}
 				})
 
 				Describe("graph cleanup for a rootfs on the whitelist", func() {
@@ -169,7 +169,7 @@ var _ = Describe("graph flags", func() {
 					Context("which is a symlink", func() {
 						BeforeEach(func() {
 							Expect(os.MkdirAll("/var/vcap/packages", 0755)).To(Succeed())
-							err := exec.Command("ln", "-s", runner.RootFSPath, "/var/vcap/packages/busybox").Run()
+							err := exec.Command("ln", "-s", os.Getenv("GARDEN_TEST_ROOTFS"), "/var/vcap/packages/busybox").Run()
 							Expect(err).ToNot(HaveOccurred())
 
 							persistentImages = []string{"/var/vcap/packages/busybox"}

--- a/gqt/rootfs_test.go
+++ b/gqt/rootfs_test.go
@@ -62,14 +62,14 @@ var _ = Describe("Rootfs container create parameter", func() {
 		It("creates successfully if a rootfs is supplied in container spec", func() {
 			var err error
 
-			container, err = client.Create(garden.ContainerSpec{RootFSPath: runner.RootFSPath})
+			container, err = client.Create(garden.ContainerSpec{RootFSPath: os.Getenv("GARDEN_TEST_ROOTFS")})
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
 	Context("with a default rootfs", func() {
 		BeforeEach(func() {
-			args = append(args, "--default-rootfs", runner.RootFSPath)
+			args = append(args, "--default-rootfs", os.Getenv("GARDEN_TEST_ROOTFS"))
 		})
 
 		It("the container is created successfully", func() {

--- a/rundmc/dadoo/execrunner_linux_test.go
+++ b/rundmc/dadoo/execrunner_linux_test.go
@@ -176,7 +176,7 @@ var _ = Describe("Dadoo ExecRunner", func() {
 					processPath,
 					"some-handle",
 					&garden.TTYSpec{
-						&garden.WindowSize{
+						WindowSize: &garden.WindowSize{
 							Rows:    12,
 							Columns: 13,
 						},
@@ -324,7 +324,7 @@ var _ = Describe("Dadoo ExecRunner", func() {
 						processPath,
 						"some-handle",
 						&garden.TTYSpec{
-							&garden.WindowSize{
+							WindowSize: &garden.WindowSize{
 								Columns: 13,
 								Rows:    17,
 							},
@@ -333,7 +333,7 @@ var _ = Describe("Dadoo ExecRunner", func() {
 					)
 					Expect(err).NotTo(HaveOccurred())
 
-					process.SetTTY(garden.TTYSpec{&garden.WindowSize{Columns: 53, Rows: 59}})
+					process.SetTTY(garden.TTYSpec{WindowSize: &garden.WindowSize{Columns: 53, Rows: 59}})
 
 					Eventually(received, "5s").Should(BeClosed())
 					Expect(receivedWinSize).To(Equal(


### PR DESCRIPTION
Note: we were not able to run unit-tests. We got errors even when running a totally clean version of garden-runc. So we are submitting the PR but this needs to be tested before getting pulling in.

``` 
mkdir /var/run/netns failed: Permission denied
Cannot remove namespace file "/var/run/netns/my-netns-1": No such file or directory
• Failure in Spec Setup (BeforeEach) [0.022 seconds]
Container [BeforeEach] when the container interface does not exist returns the error
/home/pivotal/workspace/garden-runc-release/src/code.cloudfoundry.org/guardian/kawasaki/configure/container_linux_test.go:148

  No future change is possible.  Bailing out early after 0.010s.
  Expected
      <int>: 1
  to match exit code:
      <int>: 0

  /home/pivotal/workspace/garden-runc-release/src/code.cloudfoundry.org/guardian/kawasaki/configure/container_linux_test.go:49`
```

@jenspinney && @nimakaviani