### PR TITLE
Grootfs volume creator

### DIFF
--- a/gardener/gardener.go
+++ b/gardener/gardener.go
@@ -206,10 +206,6 @@ func (g *Gardener) Create(spec garden.ContainerSpec) (ctr garden.Container, err 
 		return nil, err
 	}
 
-	if err := g.VolumeCreator.GC(log); err != nil {
-		log.Error("graph-cleanup-failed", err)
-	}
-
 	var rootFSPath string
 	var env []string
 

--- a/gardener/gardener_test.go
+++ b/gardener/gardener_test.go
@@ -108,21 +108,6 @@ var _ = Describe("Gardener", func() {
 			})
 		})
 
-		It("runs the graph cleanup", func() {
-			_, err := gdnr.Create(garden.ContainerSpec{})
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(volumeCreator.GCCallCount()).To(Equal(1))
-		})
-
-		Context("when the graph cleanup fails", func() {
-			It("does NOT return the error", func() {
-				volumeCreator.GCReturns(errors.New("graph-cleanup-fail"))
-				_, err := gdnr.Create(garden.ContainerSpec{})
-				Expect(err).NotTo(HaveOccurred())
-			})
-		})
-
 		Context("when parsing the rootfs path fails", func() {
 			It("should return an error", func() {
 				_, err := gdnr.Create(garden.ContainerSpec{

--- a/gqt/cmd/fake_grootfs/main.go
+++ b/gqt/cmd/fake_grootfs/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	storePath := os.Args[2]
+	imageID := os.Args[len(os.Args)-1]
+
+	if imageID == "make-it-fail" {
+		panic("grootfs-exploded")
+	}
+
+	// Grootfs will create bundles folder if not existent
+	bundlesPath := filepath.Join(storePath, "bundles")
+	if _, err := os.Stat(bundlesPath); err != nil {
+		if err := os.Mkdir(bundlesPath, 0777); err != nil {
+			panic(err)
+		}
+	}
+
+	bundlePath := filepath.Join(bundlesPath, imageID)
+	if err := os.Mkdir(bundlePath, 0777); err != nil {
+		panic(err)
+	}
+
+	rootfsPath := filepath.Join(bundlePath, "rootfs")
+	if err := os.Mkdir(rootfsPath, 0777); err != nil {
+		panic(err)
+	}
+
+	err := ioutil.WriteFile(filepath.Join(rootfsPath, "args"), []byte(fmt.Sprintf("%s", os.Args)), 0777)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf(rootfsPath)
+}

--- a/gqt/gqt_suite_test.go
+++ b/gqt/gqt_suite_test.go
@@ -23,7 +23,7 @@ var defaultRuntime = map[string]string{
 
 var ginkgoIO = garden.ProcessIO{Stdout: GinkgoWriter, Stderr: GinkgoWriter}
 
-var ociRuntimeBin, gardenBin, initBin, nstarBin, dadooBin, inspectorGardenBin, testNetPluginBin string
+var ociRuntimeBin, gardenBin, initBin, nstarBin, dadooBin, grootfsBin, inspectorGardenBin, testNetPluginBin string
 
 func TestGqt(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -53,6 +53,9 @@ func TestGqt(t *testing.T) {
 			bins["test_net_plugin_bin_path"], err = gexec.Build("code.cloudfoundry.org/guardian/gqt/cmd/networkplugin")
 			Expect(err).NotTo(HaveOccurred())
 
+			bins["test_grootfs_bin_path"], err = gexec.Build("code.cloudfoundry.org/guardian/gqt/cmd/fake_grootfs")
+			Expect(err).NotTo(HaveOccurred())
+
 			cmd := exec.Command("make")
 			cmd.Dir = "../rundmc/nstar"
 			cmd.Stdout = GinkgoWriter
@@ -73,6 +76,7 @@ func TestGqt(t *testing.T) {
 		gardenBin = bins["garden_bin_path"]
 		nstarBin = bins["nstar_bin_path"]
 		dadooBin = bins["dadoo_bin_bin_bin"]
+		grootfsBin = bins["test_grootfs_bin_path"]
 		initBin = bins["init_bin_path"]
 		inspectorGardenBin = bins["inspector-garden_bin_path"]
 		testNetPluginBin = bins["test_net_plugin_bin_path"]
@@ -97,7 +101,7 @@ func TestGqt(t *testing.T) {
 }
 
 func startGarden(argv ...string) *runner.RunningGarden {
-	return runner.Start(gardenBin, initBin, nstarBin, dadooBin, true, argv...)
+	return runner.Start(gardenBin, initBin, nstarBin, dadooBin, grootfsBin, true, argv...)
 }
 
 func restartGarden(client *runner.RunningGarden, argv ...string) {
@@ -107,5 +111,5 @@ func restartGarden(client *runner.RunningGarden, argv ...string) {
 }
 
 func startGardenWithoutDefaultRootfs(argv ...string) *runner.RunningGarden {
-	return runner.Start(gardenBin, initBin, nstarBin, dadooBin, false, argv...)
+	return runner.Start(gardenBin, initBin, nstarBin, dadooBin, grootfsBin, false, argv...)
 }

--- a/gqt/runner/runner.go
+++ b/gqt/runner/runner.go
@@ -73,7 +73,7 @@ func init() {
 	}
 }
 
-func NewGardenRunner(bin, initBin, nstarBin, dadooBin string, supplyDefaultRootfs bool, argv ...string) GardenRunner {
+func NewGardenRunner(bin, initBin, nstarBin, dadooBin, grootfsBin string, supplyDefaultRootfs bool, argv ...string) GardenRunner {
 	r := GardenRunner{}
 
 	r.Network = "unix"
@@ -89,7 +89,7 @@ func NewGardenRunner(bin, initBin, nstarBin, dadooBin string, supplyDefaultRootf
 
 	MustMountTmpfs(r.GraphPath)
 
-	r.Cmd = cmd(r.TmpDir, r.DepotDir, r.GraphPath, r.Network, r.Addr, bin, initBin, nstarBin, dadooBin, TarBin, supplyDefaultRootfs, argv...)
+	r.Cmd = cmd(r.TmpDir, r.DepotDir, r.GraphPath, r.Network, r.Addr, bin, initBin, nstarBin, dadooBin, TarBin, grootfsBin, supplyDefaultRootfs, argv...)
 	r.Cmd.Env = append(os.Environ(), fmt.Sprintf("TMPDIR=%s", r.TmpDir))
 
 	for i, arg := range r.Cmd.Args {
@@ -112,8 +112,8 @@ func NewGardenRunner(bin, initBin, nstarBin, dadooBin string, supplyDefaultRootf
 	return r
 }
 
-func Start(bin, initBin, nstarBin, dadooBin string, supplyDefaultRootfs bool, argv ...string) *RunningGarden {
-	runner := NewGardenRunner(bin, initBin, nstarBin, dadooBin, supplyDefaultRootfs, argv...)
+func Start(bin, initBin, nstarBin, dadooBin, grootfsBin string, supplyDefaultRootfs bool, argv ...string) *RunningGarden {
+	runner := NewGardenRunner(bin, initBin, nstarBin, dadooBin, grootfsBin, supplyDefaultRootfs, argv...)
 
 	r := &RunningGarden{
 		runner:   runner,
@@ -177,7 +177,7 @@ func (r *RunningGarden) Stop() error {
 	return err
 }
 
-func cmd(tmpdir, depotDir, graphPath, network, addr, bin, initBin, nstarBin, dadooBin, tarBin string, supplyDefaultRootfs bool, argv ...string) *exec.Cmd {
+func cmd(tmpdir, depotDir, graphPath, network, addr, bin, initBin, nstarBin, dadooBin, tarBin, grootfsBin string, supplyDefaultRootfs bool, argv ...string) *exec.Cmd {
 	Expect(os.MkdirAll(tmpdir, 0755)).To(Succeed())
 
 	snapshotsPath := filepath.Join(tmpdir, "snapshots")
@@ -222,6 +222,7 @@ func cmd(tmpdir, depotDir, graphPath, network, addr, bin, initBin, nstarBin, dad
 	gardenArgs = appendDefaultFlag(gardenArgs, "--dadoo-bin", dadooBin)
 	gardenArgs = appendDefaultFlag(gardenArgs, "--nstar-bin", nstarBin)
 	gardenArgs = appendDefaultFlag(gardenArgs, "--tar-bin", tarBin)
+	gardenArgs = appendDefaultFlag(gardenArgs, "--oci-image-bin", grootfsBin)
 	gardenArgs = appendDefaultFlag(gardenArgs, "--port-pool-start", fmt.Sprintf("%d", GinkgoParallelNode()*10000))
 	gardenArgs = appendDefaultFlag(gardenArgs, "--debug-bind-ip", "0.0.0.0")
 	gardenArgs = appendDefaultFlag(gardenArgs, "--debug-bind-port", fmt.Sprintf("%d", 8080+ginkgo.GinkgoParallelNode()))

--- a/volplugin/composite_volume_creator.go
+++ b/volplugin/composite_volume_creator.go
@@ -1,0 +1,87 @@
+package volplugin
+
+import (
+	"strings"
+
+	"code.cloudfoundry.org/garden"
+	"code.cloudfoundry.org/garden-shed/rootfs_provider"
+	"code.cloudfoundry.org/guardian/gardener"
+	"code.cloudfoundry.org/lager"
+)
+
+func NewCompositeVolumeCreator(grootfsVC, gardenShedVC gardener.VolumeCreator, pm gardener.PropertyManager) *CompositeVolumeCreator {
+	return &CompositeVolumeCreator{
+		grootfsVC:       grootfsVC,
+		gardenShedVC:    gardenShedVC,
+		propertyManager: pm,
+	}
+}
+
+type CompositeVolumeCreator struct {
+	propertyManager gardener.PropertyManager
+	grootfsVC       gardener.VolumeCreator
+	gardenShedVC    gardener.VolumeCreator
+}
+
+func (vc *CompositeVolumeCreator) Create(log lager.Logger, handle string, spec rootfs_provider.Spec) (string, []string, error) {
+	log = log.Session("volume-plugin.creating", lager.Data{"handle": handle, "spec": spec})
+	log.Debug("start")
+	defer log.Debug("end")
+
+	var volumeCreator gardener.VolumeCreator
+	if strings.HasPrefix(spec.RootFS.Scheme, "grootfs+") {
+		log.Debug("grootfs-volume-creator-selected")
+
+		spec.RootFS.Scheme = strings.Replace(spec.RootFS.Scheme, "grootfs+", "", 1)
+		vc.propertyManager.Set(handle, "volumePlugin", "grootfs")
+		volumeCreator = vc.grootfsVC
+	} else {
+		log.Debug("garden-shed-volume-creator-selected")
+
+		vc.propertyManager.Set(handle, "volumePlugin", "garden-shed")
+		volumeCreator = vc.gardenShedVC
+	}
+
+	if err := volumeCreator.GC(log); err != nil {
+		log.Error("graph-cleanup-failed", err)
+	}
+
+	return volumeCreator.Create(log, handle, spec)
+}
+
+func (vc *CompositeVolumeCreator) Destroy(log lager.Logger, handle string) error {
+	log = log.Session("volume-plugin.destroying", lager.Data{"handle": handle})
+	log.Debug("start")
+	defer log.Debug("end")
+
+	volumeCreator := vc.decideVolumeCreator(log, handle)
+	return volumeCreator.Destroy(log, handle)
+}
+
+func (vc *CompositeVolumeCreator) Metrics(log lager.Logger, handle string) (garden.ContainerDiskStat, error) {
+	log = log.Session("volume-plugin.metrics", lager.Data{"handle": handle})
+	log.Debug("start")
+	defer log.Debug("end")
+
+	volumeCreator := vc.decideVolumeCreator(log, handle)
+	return volumeCreator.Metrics(log, handle)
+}
+
+func (vc *CompositeVolumeCreator) GC(log lager.Logger) error {
+	log = log.Session("volume-plugin.gc")
+	log.Debug("start")
+	defer log.Debug("end")
+
+	return vc.gardenShedVC.GC(log)
+}
+
+func (vc *CompositeVolumeCreator) decideVolumeCreator(log lager.Logger, handle string) gardener.VolumeCreator {
+	plugin, _ := vc.propertyManager.Get(handle, "volumePlugin")
+	if plugin == "grootfs" {
+		log.Debug("grootfs-volume-creator-selected")
+		return vc.grootfsVC
+	}
+
+	log.Debug("garden-shed-volume-creator-selected")
+	return vc.gardenShedVC
+}

--- a/volplugin/composite_volume_creator_test.go
+++ b/volplugin/composite_volume_creator_test.go
@@ -1,0 +1,315 @@
+package volplugin_test
+
+import (
+	"errors"
+	"net/url"
+
+	"code.cloudfoundry.org/garden"
+	"code.cloudfoundry.org/garden-shed/rootfs_provider"
+	"code.cloudfoundry.org/guardian/gardener/gardenerfakes"
+	"code.cloudfoundry.org/guardian/volplugin"
+	"code.cloudfoundry.org/lager/lagertest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+)
+
+var _ = Describe("CompositeVolumeCreator", func() {
+	var (
+		fakePM           *gardenerfakes.FakePropertyManager
+		fakeGrootfsVC    *gardenerfakes.FakeVolumeCreator
+		fakeGardenShedVC *gardenerfakes.FakeVolumeCreator
+		logger           *lagertest.TestLogger
+
+		compositeVolumeCreator *volplugin.CompositeVolumeCreator
+	)
+
+	BeforeEach(func() {
+		logger = lagertest.NewTestLogger("composite-volume-creator")
+		fakeGrootfsVC = new(gardenerfakes.FakeVolumeCreator)
+		fakeGardenShedVC = new(gardenerfakes.FakeVolumeCreator)
+		fakePM = new(gardenerfakes.FakePropertyManager)
+		compositeVolumeCreator = volplugin.NewCompositeVolumeCreator(fakeGrootfsVC, fakeGardenShedVC, fakePM)
+	})
+
+	Describe("Create", func() {
+		var rootfs *url.URL
+
+		Context("when it's not a groofs url", func() {
+			BeforeEach(func() {
+				var err error
+				rootfs, err = url.Parse("http://hello.com")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("uses the garden-shed volume creator", func() {
+				_, _, err := compositeVolumeCreator.Create(logger, "image-id", rootfs_provider.Spec{RootFS: rootfs})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(fakeGrootfsVC.CreateCallCount()).To(Equal(0))
+				Expect(fakeGardenShedVC.CreateCallCount()).To(Equal(1))
+
+				_, handler, spec := fakeGardenShedVC.CreateArgsForCall(0)
+				Expect(handler).To(Equal("image-id"))
+				Expect(spec).To(Equal(rootfs_provider.Spec{RootFS: rootfs}))
+			})
+
+			It("returns the same returns of the garden-shed volume creator", func() {
+				expectedRootFSPathReturn := "/some/place/here"
+				expectedEnvsReturn := []string{"HELLO", "THERE"}
+				expectedErrorReturn := errors.New("sorry!")
+				fakeGardenShedVC.CreateReturns(expectedRootFSPathReturn, expectedEnvsReturn, expectedErrorReturn)
+
+				rootfsPath, envs, err := compositeVolumeCreator.Create(logger, "image-id", rootfs_provider.Spec{RootFS: rootfs})
+				Expect(rootfsPath).To(Equal(expectedRootFSPathReturn))
+				Expect(envs).To(Equal(expectedEnvsReturn))
+				Expect(err).To(Equal(expectedErrorReturn))
+			})
+
+			It("writes to the property manager the volumePlugin property", func() {
+				_, _, err := compositeVolumeCreator.Create(logger, "image-id", rootfs_provider.Spec{RootFS: rootfs})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(fakePM.SetCallCount()).To(Equal(1))
+				handle, property, value := fakePM.SetArgsForCall(0)
+
+				Expect(handle).To(Equal("image-id"))
+				Expect(property).To(Equal("volumePlugin"))
+				Expect(value).To(Equal("garden-shed"))
+			})
+
+			It("uses the garden-shed volume creator to GC", func() {
+				_, _, err := compositeVolumeCreator.Create(logger, "image-id", rootfs_provider.Spec{RootFS: rootfs})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(fakeGrootfsVC.GCCallCount()).To(Equal(0))
+				Expect(fakeGardenShedVC.GCCallCount()).To(Equal(1))
+			})
+
+			Context("when calling the GC fails", func() {
+				BeforeEach(func() {
+					fakeGardenShedVC.GCReturns(errors.New("failed to GC"))
+				})
+
+				It("doesn't fail, but logs the error", func() {
+					_, _, err := compositeVolumeCreator.Create(logger, "image-id", rootfs_provider.Spec{RootFS: rootfs})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(logger.TestSink.Buffer()).To(gbytes.Say("failed to GC"))
+				})
+			})
+		})
+
+		Context("when it's a groofs url", func() {
+			BeforeEach(func() {
+				var err error
+				rootfs, err = url.Parse("grootfs+docker:///hello.com")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("uses the grootfs volume creator", func() {
+				_, _, err := compositeVolumeCreator.Create(logger, "image-id", rootfs_provider.Spec{RootFS: rootfs})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(fakeGardenShedVC.CreateCallCount()).To(Equal(0))
+				Expect(fakeGrootfsVC.CreateCallCount()).To(Equal(1))
+			})
+
+			It("returns the same returns of the grootfs volume creator", func() {
+				expectedRootFSPathReturn := "/some/place/here"
+				expectedEnvsReturn := []string{"HELLO", "THERE"}
+				expectedErrorReturn := errors.New("sorry!")
+				fakeGrootfsVC.CreateReturns(expectedRootFSPathReturn, expectedEnvsReturn, expectedErrorReturn)
+
+				rootfsPath, envs, err := compositeVolumeCreator.Create(logger, "image-id", rootfs_provider.Spec{RootFS: rootfs})
+				Expect(rootfsPath).To(Equal(expectedRootFSPathReturn))
+				Expect(envs).To(Equal(expectedEnvsReturn))
+				Expect(err).To(Equal(expectedErrorReturn))
+			})
+
+			It("removes the `grootfs+` part of the given rootfs", func() {
+				_, _, err := compositeVolumeCreator.Create(logger, "image-id", rootfs_provider.Spec{RootFS: rootfs})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(fakeGrootfsVC.CreateCallCount()).To(Equal(1))
+				_, handler, spec := fakeGrootfsVC.CreateArgsForCall(0)
+				Expect(handler).To(Equal("image-id"))
+
+				expectedRootFS, err := url.Parse("docker:///hello.com")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(spec).To(Equal(rootfs_provider.Spec{RootFS: expectedRootFS}))
+			})
+
+			It("writes to the property manager the volumePlugin property", func() {
+				_, _, err := compositeVolumeCreator.Create(logger, "image-id", rootfs_provider.Spec{RootFS: rootfs})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(fakePM.SetCallCount()).To(Equal(1))
+				handle, property, value := fakePM.SetArgsForCall(0)
+
+				Expect(handle).To(Equal("image-id"))
+				Expect(property).To(Equal("volumePlugin"))
+				Expect(value).To(Equal("grootfs"))
+			})
+
+			It("uses the grootfs volume creator to GC", func() {
+				_, _, err := compositeVolumeCreator.Create(logger, "image-id", rootfs_provider.Spec{RootFS: rootfs})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(fakeGardenShedVC.GCCallCount()).To(Equal(0))
+				Expect(fakeGrootfsVC.GCCallCount()).To(Equal(1))
+			})
+
+			Context("when calling the GC fails", func() {
+				BeforeEach(func() {
+					fakeGrootfsVC.GCReturns(errors.New("failed to GC"))
+				})
+
+				It("doesn't fail, but logs the error", func() {
+					_, _, err := compositeVolumeCreator.Create(logger, "image-id", rootfs_provider.Spec{RootFS: rootfs})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(logger.TestSink.Buffer()).To(gbytes.Say("failed to GC"))
+				})
+			})
+		})
+	})
+
+	Describe("Destroy", func() {
+		BeforeEach(func() {
+			fakePM.GetStub = func(handle string, name string) (string, bool) {
+				if handle == "grootfs-image-id" {
+					if name == "volumePlugin" {
+						return "grootfs", true
+					}
+				}
+
+				return "", false
+			}
+		})
+		Context("when the property manager doesn't tell it's a grootfs image", func() {
+			It("uses the garden-shed volume creator", func() {
+				err := compositeVolumeCreator.Destroy(logger, "image-id")
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(fakeGrootfsVC.DestroyCallCount()).To(Equal(0))
+				Expect(fakeGardenShedVC.DestroyCallCount()).To(Equal(1))
+
+				_, handler := fakeGardenShedVC.DestroyArgsForCall(0)
+				Expect(handler).To(Equal("image-id"))
+			})
+
+			Context("when garden-shed volume creator fails", func() {
+				BeforeEach(func() {
+					fakeGardenShedVC.DestroyReturns(errors.New("failed!"))
+				})
+
+				It("fails with the same error", func() {
+					err := compositeVolumeCreator.Destroy(logger, "image-id")
+					Expect(err).To(MatchError("failed!"))
+				})
+			})
+		})
+
+		Context("when the property manager tells it's a grootfs image", func() {
+			It("uses the grootfs volume creator", func() {
+				err := compositeVolumeCreator.Destroy(logger, "grootfs-image-id")
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(fakeGardenShedVC.DestroyCallCount()).To(Equal(0))
+				Expect(fakeGrootfsVC.DestroyCallCount()).To(Equal(1))
+
+				_, handler := fakeGrootfsVC.DestroyArgsForCall(0)
+				Expect(handler).To(Equal("grootfs-image-id"))
+			})
+
+			Context("when grootfs volume creator fails", func() {
+				BeforeEach(func() {
+					fakeGrootfsVC.DestroyReturns(errors.New("failed!"))
+				})
+
+				It("fails with the same error", func() {
+					err := compositeVolumeCreator.Destroy(logger, "grootfs-image-id")
+					Expect(err).To(MatchError("failed!"))
+				})
+			})
+		})
+	})
+
+	Describe("Metrics", func() {
+		BeforeEach(func() {
+			fakePM.GetStub = func(handle string, name string) (string, bool) {
+				if handle == "grootfs-image-id" {
+					if name == "volumePlugin" {
+						return "grootfs", true
+					}
+				}
+
+				return "", false
+			}
+		})
+		Context("when the property manager doesn't tell it's a grootfs image", func() {
+			It("uses the garden-shed volume creator", func() {
+				_, err := compositeVolumeCreator.Metrics(logger, "image-id")
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(fakeGrootfsVC.MetricsCallCount()).To(Equal(0))
+				Expect(fakeGardenShedVC.MetricsCallCount()).To(Equal(1))
+
+				_, handler := fakeGardenShedVC.MetricsArgsForCall(0)
+				Expect(handler).To(Equal("image-id"))
+			})
+
+			It("returns the whatever garden-shed volume creator returns", func() {
+				expectedContainerDiskStatReturn := garden.ContainerDiskStat{
+					TotalBytesUsed: 666,
+				}
+				expectedErrorReturn := errors.New("crash")
+				fakeGardenShedVC.MetricsReturns(expectedContainerDiskStatReturn, expectedErrorReturn)
+
+				diskStat, err := compositeVolumeCreator.Metrics(logger, "image-id")
+				Expect(diskStat).To(Equal(expectedContainerDiskStatReturn))
+				Expect(err).To(MatchError(expectedErrorReturn))
+			})
+		})
+
+		Context("when the property manager tells it's a grootfs image", func() {
+			It("uses the grootfs volume creator", func() {
+				_, err := compositeVolumeCreator.Metrics(logger, "grootfs-image-id")
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(fakeGardenShedVC.MetricsCallCount()).To(Equal(0))
+				Expect(fakeGrootfsVC.MetricsCallCount()).To(Equal(1))
+
+				_, handler := fakeGrootfsVC.MetricsArgsForCall(0)
+				Expect(handler).To(Equal("grootfs-image-id"))
+			})
+
+			It("returns the whatever grootfs volume creator returns", func() {
+				expectedContainerDiskStatReturn := garden.ContainerDiskStat{
+					TotalBytesUsed: 666,
+				}
+				expectedErrorReturn := errors.New("crash")
+				fakeGrootfsVC.MetricsReturns(expectedContainerDiskStatReturn, expectedErrorReturn)
+
+				diskStat, err := compositeVolumeCreator.Metrics(logger, "grootfs-image-id")
+				Expect(diskStat).To(Equal(expectedContainerDiskStatReturn))
+				Expect(err).To(MatchError(expectedErrorReturn))
+			})
+		})
+	})
+
+	Describe("GC", func() {
+		It("uses the garden-shed volume creator", func() {
+			Expect(compositeVolumeCreator.GC(logger)).To(Succeed())
+
+			Expect(fakeGrootfsVC.GCCallCount()).To(Equal(0))
+			Expect(fakeGardenShedVC.GCCallCount()).To(Equal(1))
+		})
+
+		It("returns the same error that the garden-shed volume creator returns", func() {
+			fakeGardenShedVC.GCReturns(errors.New("garden-shed error"))
+
+			err := compositeVolumeCreator.GC(logger)
+			Expect(err).To(MatchError("garden-shed error"))
+		})
+	})
+})

--- a/volplugin/grootfs.go
+++ b/volplugin/grootfs.go
@@ -1,0 +1,86 @@
+package volplugin
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+
+	"code.cloudfoundry.org/garden"
+	"code.cloudfoundry.org/garden-shed/rootfs_provider"
+	"code.cloudfoundry.org/lager"
+	"github.com/cloudfoundry/gunk/command_runner"
+)
+
+func NewGrootfsVC(binPath, storePath string, commandRunner command_runner.CommandRunner) *GrootfsVC {
+	return &GrootfsVC{
+		binPath:       binPath,
+		storePath:     storePath,
+		commandRunner: commandRunner,
+	}
+}
+
+type GrootfsVC struct {
+	binPath       string
+	storePath     string
+	commandRunner command_runner.CommandRunner
+}
+
+func (vc *GrootfsVC) Create(log lager.Logger, handle string, spec rootfs_provider.Spec) (string, []string, error) {
+	log = log.Session("grootfs-create")
+	log.Debug("start")
+	defer log.Debug("end")
+
+	cmd := exec.Command(
+		vc.binPath,
+		"--store", vc.storePath,
+		"create",
+		spec.RootFS.String(),
+		handle,
+	)
+
+	errBuffer := bytes.NewBuffer([]byte{})
+	cmd.Stderr = errBuffer
+	outBuffer := bytes.NewBuffer([]byte{})
+	cmd.Stdout = outBuffer
+
+	if err := vc.commandRunner.Run(cmd); err != nil {
+		return "", nil, fmt.Errorf("running grootfs create: %s - %s", err, errBuffer.String())
+	}
+
+	return outBuffer.String(), []string{}, nil
+}
+func (vc *GrootfsVC) Destroy(log lager.Logger, handle string) error {
+	log = log.Session("grootfs-destroy")
+	log.Debug("start")
+	defer log.Debug("end")
+
+	cmd := exec.Command(
+		vc.binPath,
+		"--store", vc.storePath,
+		"delete",
+		handle,
+	)
+
+	errBuffer := bytes.NewBuffer([]byte{})
+	cmd.Stderr = errBuffer
+
+	if err := vc.commandRunner.Run(cmd); err != nil {
+		return fmt.Errorf("running grootfs delete: %s - %s", err, errBuffer.String())
+	}
+
+	return nil
+}
+func (vc *GrootfsVC) Metrics(log lager.Logger, handle string) (garden.ContainerDiskStat, error) {
+	log = log.Session("grootfs-metrics")
+	log.Debug("start")
+	defer log.Debug("end")
+
+	return garden.ContainerDiskStat{}, nil
+}
+func (vc *GrootfsVC) GC(log lager.Logger) error {
+	log = log.Session("grootfs-gc")
+	log.Debug("start")
+	defer log.Debug("end")
+
+	return nil
+}

--- a/volplugin/grootfs_test.go
+++ b/volplugin/grootfs_test.go
@@ -1,0 +1,217 @@
+package volplugin_test
+
+import (
+	"errors"
+	"net/url"
+	"os/exec"
+
+	"code.cloudfoundry.org/garden-shed/rootfs_provider"
+	"code.cloudfoundry.org/guardian/volplugin"
+	"code.cloudfoundry.org/lager/lagertest"
+	"github.com/cloudfoundry/gunk/command_runner/fake_command_runner"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Grootfs", func() {
+	var (
+		fakeCommandRunner *fake_command_runner.FakeCommandRunner
+		logger            *lagertest.TestLogger
+		grootfsVC         *volplugin.GrootfsVC
+		imageSource       *url.URL
+	)
+
+	BeforeEach(func() {
+		logger = lagertest.NewTestLogger("grootfs")
+		fakeCommandRunner = fake_command_runner.New()
+		grootfsVC = volplugin.NewGrootfsVC("/grootfs-bin", "/var/vcap/data/grootfs", fakeCommandRunner)
+
+		var err error
+		imageSource, err = url.Parse("/hello/image")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Describe("Create", func() {
+		It("uses the correct grootfs binary", func() {
+			_, _, err := grootfsVC.Create(logger, "hello", rootfs_provider.Spec{
+				RootFS: imageSource,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
+			grootfsCmd := fakeCommandRunner.ExecutedCommands()[0]
+
+			Expect(grootfsCmd.Path).To(Equal("/grootfs-bin"))
+		})
+
+		It("uses the grootfs binary output as the rootpath return", func() {
+			fakeCommandRunner.WhenRunning(fake_command_runner.CommandSpec{
+				Path: "/grootfs-bin",
+			}, func(cmd *exec.Cmd) error {
+				cmd.Stdout.Write([]byte("/this-is/your-rootfs"))
+				cmd.Stderr.Write([]byte("/this-is-not/your-rootfs"))
+				return nil
+			})
+
+			rootfs, _, err := grootfsVC.Create(logger, "hello", rootfs_provider.Spec{
+				RootFS: imageSource,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(rootfs).To(Equal("/this-is/your-rootfs"))
+		})
+
+		It("doesn't support image env yet", func() {
+			_, envs, err := grootfsVC.Create(logger, "hello", rootfs_provider.Spec{
+				RootFS: imageSource,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(envs).To(Equal([]string{}))
+		})
+
+		Context("grootfs parameters", func() {
+			It("sets the correct grootfs store path", func() {
+				_, _, err := grootfsVC.Create(logger, "hello", rootfs_provider.Spec{
+					RootFS: imageSource,
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
+				grootfsCmd := fakeCommandRunner.ExecutedCommands()[0]
+
+				Expect(grootfsCmd.Args[1]).To(Equal("--store"))
+				Expect(grootfsCmd.Args[2]).To(Equal("/var/vcap/data/grootfs"))
+			})
+
+			It("uses the correct grootfs create command", func() {
+				_, _, err := grootfsVC.Create(logger, "hello", rootfs_provider.Spec{
+					RootFS: imageSource,
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
+				grootfsCmd := fakeCommandRunner.ExecutedCommands()[0]
+
+				Expect(grootfsCmd.Args[3]).To(Equal("create"))
+			})
+
+			It("sets the correct image input to grootfs", func() {
+				_, _, err := grootfsVC.Create(logger, "hello", rootfs_provider.Spec{
+					RootFS: imageSource,
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
+				grootfsCmd := fakeCommandRunner.ExecutedCommands()[0]
+
+				Expect(grootfsCmd.Args[4]).To(Equal("/hello/image"))
+			})
+
+			It("sets the correct id to grootfs", func() {
+				_, _, err := grootfsVC.Create(logger, "hello", rootfs_provider.Spec{
+					RootFS: imageSource,
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
+				grootfsCmd := fakeCommandRunner.ExecutedCommands()[0]
+
+				Expect(grootfsCmd.Args[5]).To(Equal("hello"))
+			})
+		})
+
+		Context("when the command fails", func() {
+			BeforeEach(func() {
+				fakeCommandRunner.WhenRunning(fake_command_runner.CommandSpec{
+					Path: "/grootfs-bin",
+				}, func(cmd *exec.Cmd) error {
+					cmd.Stderr.Write([]byte("btrfs doesn't like you"))
+
+					return errors.New("grootfs failure")
+				})
+			})
+
+			It("returns an error", func() {
+				_, _, err := grootfsVC.Create(logger, "hello", rootfs_provider.Spec{
+					RootFS: imageSource,
+				})
+				Expect(err).To(MatchError(ContainSubstring("grootfs failure")))
+			})
+
+			It("returns the grootfs error output in the error", func() {
+				_, _, err := grootfsVC.Create(logger, "hello", rootfs_provider.Spec{
+					RootFS: imageSource,
+				})
+				Expect(err).To(MatchError(ContainSubstring("btrfs doesn't like you")))
+			})
+		})
+	})
+
+	Describe("Destroy", func() {
+		It("uses the correct grootfs binary", func() {
+			err := grootfsVC.Destroy(logger, "hello")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
+			grootfsCmd := fakeCommandRunner.ExecutedCommands()[0]
+
+			Expect(grootfsCmd.Path).To(Equal("/grootfs-bin"))
+		})
+
+		Context("grootfs parameters", func() {
+			It("sets the correct grootfs store path", func() {
+				err := grootfsVC.Destroy(logger, "hello")
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
+				grootfsCmd := fakeCommandRunner.ExecutedCommands()[0]
+
+				Expect(grootfsCmd.Args[1]).To(Equal("--store"))
+				Expect(grootfsCmd.Args[2]).To(Equal("/var/vcap/data/grootfs"))
+			})
+
+			It("uses the correct grootfs delete command", func() {
+				err := grootfsVC.Destroy(logger, "hello")
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
+				grootfsCmd := fakeCommandRunner.ExecutedCommands()[0]
+
+				Expect(grootfsCmd.Args[3]).To(Equal("delete"))
+			})
+
+			It("sets the correct id to grootfs", func() {
+				err := grootfsVC.Destroy(logger, "hello")
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
+				grootfsCmd := fakeCommandRunner.ExecutedCommands()[0]
+
+				Expect(grootfsCmd.Args[4]).To(Equal("hello"))
+			})
+		})
+
+		Context("when the command fails", func() {
+			BeforeEach(func() {
+				fakeCommandRunner.WhenRunning(fake_command_runner.CommandSpec{
+					Path: "/grootfs-bin",
+				}, func(cmd *exec.Cmd) error {
+					cmd.Stderr.Write([]byte("btrfs doesn't like you"))
+
+					return errors.New("grootfs failure")
+				})
+			})
+
+			It("returns an error", func() {
+				err := grootfsVC.Destroy(logger, "hello")
+				Expect(err).To(MatchError(ContainSubstring("grootfs failure")))
+			})
+
+			It("returns the grootfs error output in the error", func() {
+				err := grootfsVC.Destroy(logger, "hello")
+				Expect(err).To(MatchError(ContainSubstring("btrfs doesn't like you")))
+			})
+		})
+	})
+})

--- a/volplugin/volplugin_suite_test.go
+++ b/volplugin/volplugin_suite_test.go
@@ -1,0 +1,13 @@
+package volplugin_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestNetplugin(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "volplugin")
+}


### PR DESCRIPTION
Enable garden to use grootfs to create rootfs filesystems, when the path begins with `grootfs+`.

e.g.
```
grootfs+docker:///ubuntu
```

* Adds the grootfs volume creator, that should shell out to the `--oci-image-bin`. 
* Replace the `VolumeCreator` used in the `Gardener` with a `CompositeVolumeCreator`.
* `CompositeVolumeCreator` implements the VolumeCreator interface and is aware of the GrootFS VC and the GardenShed VC. It then decides with volume creator to use for each operation, based on the rootfs url scheme.
* `CompositeVolumeCreator` also adds a new property to the container `volumePlugin` which may be `grootfs` or `garden-shed`.
* The garbage collection had to be moved from the `Gardener` to inside the `CompositeVolumeCreator` since it has no information about which container is triggering it.
* Added `fake_grootfs` binary for integration tests.
* The grootfs binary path has to be passed as an argument to garden using the `--oci-image-bin` flag.
