### PR TITLE
Use bundle path when calling grootfs destroy

### DIFF
--- a/imageplugin/external_image_manager.go
+++ b/imageplugin/external_image_manager.go
@@ -93,6 +93,7 @@ func (p *ExternalImageManager) Destroy(log lager.Logger, handle, rootfs string) 
 	log.Debug("start")
 	defer log.Debug("end")
 
+	rootfs = strings.TrimRight(rootfs, "/rootfs")
 	cmd := exec.Command(
 		p.binPath,
 		"delete",


### PR DESCRIPTION
The image plugin should call the image binary with the bundle path instead of the rootfs path when deleting.

Signed-off-by: Tiago Scolari <tscolari@pivotal.io>
Signed-off-by: I am groot.