### PR TITLE
Use bundle path instead of rootfs for img-plugin deletion

### DIFF
--- a/gqt/cmd/fake_image_plugin/main.go
+++ b/gqt/cmd/fake_image_plugin/main.go
@@ -29,37 +29,37 @@ func main() {
 		panic(err)
 	}
 
-	var imagePath string
+	var bundlePath string
 	if strings.TrimSpace(string(uid)) == "0" {
-		imagePath = fmt.Sprintf("/tmp/store-path/%s", imageID)
+		bundlePath = filepath.Join("/tmp/store-path", imageID)
 	} else {
-		imagePath = fmt.Sprintf("/tmp/unpriv-store-path/%s", imageID)
+		bundlePath = filepath.Join("/tmp/unpriv-store-path", imageID)
 	}
 	if action == "delete" {
-		imagePath = filepath.Dir(imageID)
+		bundlePath = imageID
 	}
 
 	if action == "create" {
-		rootFSPath := fmt.Sprintf("%s/rootfs", imagePath)
+		rootFSPath := filepath.Join(bundlePath, "rootfs")
 		if err := os.MkdirAll(rootFSPath, 0777); err != nil {
 			ioutil.WriteFile("/tmp/error", []byte("greshkaaa"+string(uid)+string(gid)+err.Error()), 0755)
 			panic(err)
 		}
 	}
 
-	whoamiPath := filepath.Join(imagePath, fmt.Sprintf("%s-whoami", action))
+	whoamiPath := filepath.Join(bundlePath, fmt.Sprintf("%s-whoami", action))
 	err = ioutil.WriteFile(whoamiPath, []byte(fmt.Sprintf("%s - %s\n", strings.TrimSpace(string(uid)), strings.TrimSpace(string(gid)))), 0755)
 	if err != nil {
 		ioutil.WriteFile("/tmp/error", []byte("greshkaaa"+string(uid)+string(gid)+err.Error()), 0755)
 		panic(err)
 	}
 
-	argsFilepath := filepath.Join(imagePath, fmt.Sprintf("%s-args", action))
+	argsFilepath := filepath.Join(bundlePath, fmt.Sprintf("%s-args", action))
 	err = ioutil.WriteFile(argsFilepath, []byte(fmt.Sprintf("%s", os.Args)), 0777)
 	if err != nil {
 		ioutil.WriteFile("/tmp/error", []byte("greshkaaa"+string(uid)+string(gid)+err.Error()), 0755)
 		panic(err)
 	}
 
-	fmt.Printf(imagePath)
+	fmt.Printf(bundlePath)
 }

--- a/imageplugin/external_image_manager.go
+++ b/imageplugin/external_image_manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -93,10 +94,11 @@ func (p *ExternalImageManager) Destroy(log lager.Logger, handle, rootfs string) 
 	log.Debug("start")
 	defer log.Debug("end")
 
+	bundlePath := filepath.Dir(rootfs)
 	cmd := exec.Command(
 		p.binPath,
 		"delete",
-		rootfs,
+		bundlePath,
 	)
 
 	errBuffer := bytes.NewBuffer([]byte{})

--- a/imageplugin/external_image_manager_test.go
+++ b/imageplugin/external_image_manager_test.go
@@ -239,7 +239,7 @@ var _ = Describe("ExternalImageManager", func() {
 		var err error
 
 		JustBeforeEach(func() {
-			err = externalImageManager.Destroy(logger, "hello", "rootfs")
+			err = externalImageManager.Destroy(logger, "hello", "/store/0/bundles/123/rootfs")
 		})
 
 		It("uses the correct external-image-manager binary", func() {
@@ -259,12 +259,12 @@ var _ = Describe("ExternalImageManager", func() {
 				Expect(imageManagerCmd.Args[1]).To(Equal("delete"))
 			})
 
-			It("passes the correct rootfs to delete to external-image-manager", func() {
+			It("passes the correct bundle path to delete to/ the external-image-manager", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
 				imageManagerCmd := fakeCommandRunner.ExecutedCommands()[0]
 
-				Expect(imageManagerCmd.Args[len(imageManagerCmd.Args)-1]).To(Equal("rootfs"))
+				Expect(imageManagerCmd.Args[len(imageManagerCmd.Args)-1]).To(Equal("/store/0/bundles/123"))
 			})
 		})
 

--- a/imageplugin/imageplugin_suite_test.go
+++ b/imageplugin/imageplugin_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestNetplugin(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "imageplugin")
+	RunSpecs(t, "Imageplugin Suite")
 }


### PR DESCRIPTION
The image plugin should call the image binary with the bundle path instead of the rootfs path when deleting.

Signed-off-by: Tiago Scolari tscolari@pivotal.io
Signed-off-by: I am groot.