### PR TITLE
Add imageplugin support to env variables

### DIFF
--- a/gqt/cmd/fake_image_plugin/main.go
+++ b/gqt/cmd/fake_image_plugin/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -19,45 +18,34 @@ func main() {
 		panic("image-plugin-exploded-on-destruction")
 	}
 
-	uid, err := exec.Command("id", "-u").CombinedOutput()
-	if err != nil {
-		panic(err)
-	}
-
-	gid, err := exec.Command("id", "-g").CombinedOutput()
-	if err != nil {
-		panic(err)
-	}
+	uid := os.Getuid()
+	gid := os.Getgid()
 
 	var bundlePath string
-	if strings.TrimSpace(string(uid)) == "0" {
+	if uid == 0 {
 		bundlePath = filepath.Join("/tmp/store-path", imageID)
 	} else {
 		bundlePath = filepath.Join("/tmp/unpriv-store-path", imageID)
-	}
-	if action == "delete" {
-		bundlePath = imageID
 	}
 
 	if action == "create" {
 		rootFSPath := filepath.Join(bundlePath, "rootfs")
 		if err := os.MkdirAll(rootFSPath, 0777); err != nil {
-			ioutil.WriteFile("/tmp/error", []byte("greshkaaa"+string(uid)+string(gid)+err.Error()), 0755)
 			panic(err)
 		}
+	} else if action == "delete" {
+		bundlePath = imageID
 	}
 
 	whoamiPath := filepath.Join(bundlePath, fmt.Sprintf("%s-whoami", action))
-	err = ioutil.WriteFile(whoamiPath, []byte(fmt.Sprintf("%s - %s\n", strings.TrimSpace(string(uid)), strings.TrimSpace(string(gid)))), 0755)
+	err := ioutil.WriteFile(whoamiPath, []byte(fmt.Sprintf("%d - %d\n", uid, gid)), 0755)
 	if err != nil {
-		ioutil.WriteFile("/tmp/error", []byte("greshkaaa"+string(uid)+string(gid)+err.Error()), 0755)
 		panic(err)
 	}
 
 	argsFilepath := filepath.Join(bundlePath, fmt.Sprintf("%s-args", action))
-	err = ioutil.WriteFile(argsFilepath, []byte(fmt.Sprintf("%s", os.Args)), 0777)
+	err = ioutil.WriteFile(argsFilepath, []byte(strings.Join(os.Args, " ")), 0777)
 	if err != nil {
-		ioutil.WriteFile("/tmp/error", []byte("greshkaaa"+string(uid)+string(gid)+err.Error()), 0755)
 		panic(err)
 	}
 

--- a/gqt/cmd/fake_image_plugin/main.go
+++ b/gqt/cmd/fake_image_plugin/main.go
@@ -21,33 +21,33 @@ func main() {
 	uid := os.Getuid()
 	gid := os.Getgid()
 
-	var bundlePath string
+	var imagePath string
 	if uid == 0 {
-		bundlePath = filepath.Join("/tmp/store-path", imageID)
+		imagePath = filepath.Join("/tmp/store-path", imageID)
 	} else {
-		bundlePath = filepath.Join("/tmp/unpriv-store-path", imageID)
+		imagePath = filepath.Join("/tmp/unpriv-store-path", imageID)
 	}
 
 	if action == "create" {
-		rootFSPath := filepath.Join(bundlePath, "rootfs")
+		rootFSPath := filepath.Join(imagePath, "rootfs")
 		if err := os.MkdirAll(rootFSPath, 0777); err != nil {
 			panic(err)
 		}
 	} else if action == "delete" {
-		bundlePath = imageID
+		imagePath = imageID
 	}
 
-	whoamiPath := filepath.Join(bundlePath, fmt.Sprintf("%s-whoami", action))
+	whoamiPath := filepath.Join(imagePath, fmt.Sprintf("%s-whoami", action))
 	err := ioutil.WriteFile(whoamiPath, []byte(fmt.Sprintf("%d - %d\n", uid, gid)), 0755)
 	if err != nil {
 		panic(err)
 	}
 
-	argsFilepath := filepath.Join(bundlePath, fmt.Sprintf("%s-args", action))
+	argsFilepath := filepath.Join(imagePath, fmt.Sprintf("%s-args", action))
 	err = ioutil.WriteFile(argsFilepath, []byte(strings.Join(os.Args, " ")), 0777)
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Printf(bundlePath)
+	fmt.Printf(imagePath)
 }

--- a/imageplugin/external_image_manager.go
+++ b/imageplugin/external_image_manager.go
@@ -51,7 +51,7 @@ func (p *ExternalImageManager) Create(log lager.Logger, handle string, spec root
 		}
 	}
 
-	if spec.RootFS.String() == "" {
+	if spec.RootFS == nil || spec.RootFS.String() == "" {
 		args = append(args, p.defaultBaseImage.String())
 	} else {
 		args = append(args, spec.RootFS.String())

--- a/imageplugin/external_image_manager.go
+++ b/imageplugin/external_image_manager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -82,12 +83,35 @@ func (p *ExternalImageManager) Create(log lager.Logger, handle string, spec root
 	}
 
 	imagePath := strings.TrimSpace(outBuffer.String())
+	envVars, err := p.readEnvVars(imagePath)
+	if err != nil {
+		return "", nil, err
+	}
+
 	rootFSPath := filepath.Join(imagePath, "rootfs")
-	return rootFSPath, []string{}, nil
+	return rootFSPath, envVars, nil
 }
 
 func stringifyMapping(mapping specs.LinuxIDMapping) string {
 	return fmt.Sprintf("%d:%d:%d", mapping.ContainerID, mapping.HostID, mapping.Size)
+}
+
+func (p *ExternalImageManager) readEnvVars(imagePath string) ([]string, error) {
+	imageConfigFile, err := os.Open(filepath.Join(imagePath, "image.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, nil
+		}
+
+		return nil, fmt.Errorf("could not open image configuration: %s", err)
+	}
+
+	var imageConfig Image
+	if err := json.NewDecoder(imageConfigFile).Decode(&imageConfig); err != nil {
+		return nil, fmt.Errorf("parsing image config: %s", err)
+	}
+
+	return imageConfig.Config.Env, nil
 }
 
 func (p *ExternalImageManager) Destroy(log lager.Logger, handle, rootFSPath string) error {

--- a/imageplugin/external_image_manager_test.go
+++ b/imageplugin/external_image_manager_test.go
@@ -23,9 +23,9 @@ var _ = Describe("ExternalImageManager", func() {
 		fakeCommandRunner    *fake_command_runner.FakeCommandRunner
 		logger               *lagertest.TestLogger
 		externalImageManager *imageplugin.ExternalImageManager
-		imageSource          *url.URL
+		baseImage            *url.URL
 		idMappings           []specs.LinuxIDMapping
-		defaultRootFS        *url.URL
+		defaultBaseImage     *url.URL
 	)
 
 	BeforeEach(func() {
@@ -46,11 +46,11 @@ var _ = Describe("ExternalImageManager", func() {
 		}
 
 		var err error
-		defaultRootFS, err = url.Parse("/default/rootfs")
+		defaultBaseImage, err = url.Parse("/default/image")
 		Expect(err).ToNot(HaveOccurred())
-		externalImageManager = imageplugin.New("/external-image-manager-bin", fakeCommandRunner, defaultRootFS, idMappings)
+		externalImageManager = imageplugin.New("/external-image-manager-bin", fakeCommandRunner, defaultBaseImage, idMappings)
 
-		imageSource, err = url.Parse("/hello/image")
+		baseImage, err = url.Parse("/hello/image")
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -70,7 +70,7 @@ var _ = Describe("ExternalImageManager", func() {
 		JustBeforeEach(func() {
 			returnedRootFS, _, err = externalImageManager.Create(logger, "hello", rootfs_provider.Spec{
 				QuotaSize:  testQuotaSize,
-				RootFS:     imageSource,
+				RootFS:     baseImage,
 				Namespaced: namespaced,
 			})
 		})
@@ -224,7 +224,7 @@ var _ = Describe("ExternalImageManager", func() {
 
 		Context("when a RootFS is not provided in the rootfs_provider.Spec", func() {
 			BeforeEach(func() {
-				imageSource = &url.URL{}
+				baseImage = &url.URL{}
 			})
 
 			It("passes the default rootfs to the external-image-manager", func() {
@@ -232,7 +232,7 @@ var _ = Describe("ExternalImageManager", func() {
 				Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
 				imageManagerCmd := fakeCommandRunner.ExecutedCommands()[0]
 
-				Expect(imageManagerCmd.Args[len(imageManagerCmd.Args)-2]).To(Equal(defaultRootFS.String()))
+				Expect(imageManagerCmd.Args[len(imageManagerCmd.Args)-2]).To(Equal(defaultBaseImage.String()))
 			})
 		})
 	})
@@ -241,7 +241,7 @@ var _ = Describe("ExternalImageManager", func() {
 		var err error
 
 		JustBeforeEach(func() {
-			err = externalImageManager.Destroy(logger, "hello", "/store/0/bundles/123/rootfs")
+			err = externalImageManager.Destroy(logger, "hello", "/store/0/images/123/rootfs")
 		})
 
 		It("uses the correct external-image-manager binary", func() {
@@ -261,12 +261,12 @@ var _ = Describe("ExternalImageManager", func() {
 				Expect(imageManagerCmd.Args[1]).To(Equal("delete"))
 			})
 
-			It("passes the correct bundle path to delete to/ the external-image-manager", func() {
+			It("passes the correct image path to delete to/ the external-image-manager", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
 				imageManagerCmd := fakeCommandRunner.ExecutedCommands()[0]
 
-				Expect(imageManagerCmd.Args[len(imageManagerCmd.Args)-1]).To(Equal("/store/0/bundles/123"))
+				Expect(imageManagerCmd.Args[len(imageManagerCmd.Args)-1]).To(Equal("/store/0/images/123"))
 			})
 		})
 

--- a/imageplugin/external_image_manager_test.go
+++ b/imageplugin/external_image_manager_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"os/exec"
-	"strconv"
 
 	"code.cloudfoundry.org/garden-shed/rootfs_provider"
 	"code.cloudfoundry.org/guardian/imageplugin"
@@ -26,9 +25,16 @@ var _ = Describe("ExternalImageManager", func() {
 		baseImage            *url.URL
 		idMappings           []specs.LinuxIDMapping
 		defaultBaseImage     *url.URL
+		fakeCmdRunnerStdout  string
+		fakeCmdRunnerStderr  string
+		fakeCmdRunnerErr     error
 	)
 
 	BeforeEach(func() {
+		fakeCmdRunnerStdout = "/this-is/your\n"
+		fakeCmdRunnerStderr = ""
+		fakeCmdRunnerErr = nil
+
 		logger = lagertest.NewTestLogger("external-image-manager")
 		fakeCommandRunner = fake_command_runner.New()
 
@@ -52,31 +58,30 @@ var _ = Describe("ExternalImageManager", func() {
 
 		baseImage, err = url.Parse("/hello/image")
 		Expect(err).ToNot(HaveOccurred())
+
+		fakeCommandRunner.WhenRunning(fake_command_runner.CommandSpec{
+			Path: "/external-image-manager-bin",
+		}, func(cmd *exec.Cmd) error {
+			if cmd.Stdout != nil {
+				cmd.Stdout.Write([]byte(fakeCmdRunnerStdout))
+			}
+			if cmd.Stderr != nil {
+				cmd.Stderr.Write([]byte(fakeCmdRunnerStderr))
+			}
+
+			return fakeCmdRunnerErr
+		})
 	})
 
 	Describe("Create", func() {
-		var (
-			returnedRootFS string
-			testQuotaSize  int64
-			err            error
-			namespaced     bool
-		)
-
-		BeforeEach(func() {
-			testQuotaSize = 0
-			namespaced = false
-		})
-
-		JustBeforeEach(func() {
-			returnedRootFS, _, err = externalImageManager.Create(logger, "hello", rootfs_provider.Spec{
-				QuotaSize:  testQuotaSize,
-				RootFS:     baseImage,
-				Namespaced: namespaced,
-			})
-		})
-
 		It("uses the correct external-image-manager binary", func() {
+			_, _, err := externalImageManager.Create(
+				logger, "hello", rootfs_provider.Spec{
+					RootFS: baseImage,
+				},
+			)
 			Expect(err).ToNot(HaveOccurred())
+
 			Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
 			imageManagerCmd := fakeCommandRunner.ExecutedCommands()[0]
 
@@ -85,7 +90,13 @@ var _ = Describe("ExternalImageManager", func() {
 
 		Describe("external-image-manager parameters", func() {
 			It("uses the correct external-image-manager create command", func() {
+				_, _, err := externalImageManager.Create(
+					logger, "hello", rootfs_provider.Spec{
+						RootFS: baseImage,
+					},
+				)
 				Expect(err).ToNot(HaveOccurred())
+
 				Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
 				imageManagerCmd := fakeCommandRunner.ExecutedCommands()[0]
 
@@ -93,7 +104,13 @@ var _ = Describe("ExternalImageManager", func() {
 			})
 
 			It("sets the correct image input to external-image-manager", func() {
+				_, _, err := externalImageManager.Create(
+					logger, "hello", rootfs_provider.Spec{
+						RootFS: baseImage,
+					},
+				)
 				Expect(err).ToNot(HaveOccurred())
+
 				Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
 				imageManagerCmd := fakeCommandRunner.ExecutedCommands()[0]
 
@@ -101,7 +118,13 @@ var _ = Describe("ExternalImageManager", func() {
 			})
 
 			It("sets the correct id to external-image-manager", func() {
+				_, _, err := externalImageManager.Create(
+					logger, "hello", rootfs_provider.Spec{
+						RootFS: baseImage,
+					},
+				)
 				Expect(err).ToNot(HaveOccurred())
+
 				Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
 				imageManagerCmd := fakeCommandRunner.ExecutedCommands()[0]
 
@@ -109,12 +132,15 @@ var _ = Describe("ExternalImageManager", func() {
 			})
 
 			Context("when namespaced is true", func() {
-				BeforeEach(func() {
-					namespaced = true
-				})
-
 				It("passes the correct uid and gid mappings to the external-image-manager", func() {
+					_, _, err := externalImageManager.Create(
+						logger, "hello", rootfs_provider.Spec{
+							RootFS:     baseImage,
+							Namespaced: true,
+						},
+					)
 					Expect(err).ToNot(HaveOccurred())
+
 					Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
 					imageManagerCmd := fakeCommandRunner.ExecutedCommands()[0]
 
@@ -130,7 +156,14 @@ var _ = Describe("ExternalImageManager", func() {
 				})
 
 				It("runs the external-image-manager as the container root user", func() {
+					_, _, err := externalImageManager.Create(
+						logger, "hello", rootfs_provider.Spec{
+							RootFS:     baseImage,
+							Namespaced: true,
+						},
+					)
 					Expect(err).ToNot(HaveOccurred())
+
 					Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
 					imageManagerCmd := fakeCommandRunner.ExecutedCommands()[0]
 
@@ -141,7 +174,13 @@ var _ = Describe("ExternalImageManager", func() {
 
 			Context("when namespaced is false", func() {
 				It("does not pass any uid and gid mappings to the external-image-manager", func() {
+					_, _, err := externalImageManager.Create(
+						logger, "hello", rootfs_provider.Spec{
+							RootFS: baseImage,
+						},
+					)
 					Expect(err).ToNot(HaveOccurred())
+
 					Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
 					imageManagerCmd := fakeCommandRunner.ExecutedCommands()[0]
 
@@ -151,84 +190,73 @@ var _ = Describe("ExternalImageManager", func() {
 			})
 
 			Context("when a disk quota is provided in the spec", func() {
-				BeforeEach(func() {
-					testQuotaSize = 1024
-				})
-
 				It("passes the quota to the external-image-manager", func() {
+					_, _, err := externalImageManager.Create(
+						logger, "hello", rootfs_provider.Spec{
+							RootFS:    baseImage,
+							QuotaSize: 1024,
+						},
+					)
 					Expect(err).ToNot(HaveOccurred())
+
 					Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
 					imageManagerCmd := fakeCommandRunner.ExecutedCommands()[0]
 
 					Expect(imageManagerCmd.Args[2]).To(Equal("--disk-limit-size-bytes"))
-					Expect(imageManagerCmd.Args[3]).To(Equal(strconv.FormatInt(testQuotaSize, 10)))
+					Expect(imageManagerCmd.Args[3]).To(Equal("1024"))
 				})
 			})
 		})
 
-		Context("when the external-image-manager binary prints to stdout/stderr", func() {
-			BeforeEach(func() {
-				fakeCommandRunner.WhenRunning(fake_command_runner.CommandSpec{
-					Path: "/external-image-manager-bin",
-				}, func(cmd *exec.Cmd) error {
-					cmd.Stdout.Write([]byte("/this-is/your"))
-					cmd.Stderr.Write([]byte("/this-is-not/your-rootfs"))
-					return nil
-				})
-			})
+		It("returns rootfs location", func() {
+			returnedRootFS, _, err := externalImageManager.Create(
+				logger, "hello", rootfs_provider.Spec{
+					RootFS: baseImage,
+				},
+			)
+			Expect(err).ToNot(HaveOccurred())
 
-			It("returns stdout as the rootfs location", func() {
-				Expect(err).ToNot(HaveOccurred())
-				Expect(returnedRootFS).To(Equal("/this-is/your/rootfs"))
-			})
-		})
-
-		Context("when the external-image-manager binary prints a newline ath the end of its output", func() {
-			BeforeEach(func() {
-				fakeCommandRunner.WhenRunning(fake_command_runner.CommandSpec{
-					Path: "/external-image-manager-bin",
-				}, func(cmd *exec.Cmd) error {
-					cmd.Stdout.Write([]byte("/this-is/your\n"))
-					return nil
-				})
-			})
-
-			It("returns the rootfs without the new line character", func() {
-				Expect(err).ToNot(HaveOccurred())
-				Expect(returnedRootFS).To(Equal("/this-is/your/rootfs"))
-			})
+			Expect(returnedRootFS).To(Equal("/this-is/your/rootfs"))
 		})
 
 		Context("when the command fails", func() {
 			BeforeEach(func() {
-				fakeCommandRunner.WhenRunning(fake_command_runner.CommandSpec{
-					Path: "/external-image-manager-bin",
-				}, func(cmd *exec.Cmd) error {
-					cmd.Stderr.Write([]byte("btrfs doesn't like you"))
-					cmd.Stdout.Write([]byte("could not find drax"))
-
-					return errors.New("external-image-manager failure")
-				})
+				fakeCmdRunnerStdout = "could not find drax"
+				fakeCmdRunnerStderr = "btrfs doesn't like you"
+				fakeCmdRunnerErr = errors.New("external-image-manager failure")
 			})
 
 			It("returns an error", func() {
+				_, _, err := externalImageManager.Create(
+					logger, "hello", rootfs_provider.Spec{
+						RootFS: baseImage,
+					},
+				)
+
 				Expect(err).To(MatchError(ContainSubstring("external image manager create failed")))
 				Expect(err).To(MatchError(ContainSubstring("external-image-manager failure")))
 				Expect(err).To(MatchError(ContainSubstring("could not find drax")))
 			})
 
 			It("returns the external-image-manager error output in the error", func() {
+				_, _, err := externalImageManager.Create(
+					logger, "hello", rootfs_provider.Spec{
+						RootFS: baseImage,
+					},
+				)
+				Expect(err).To(HaveOccurred())
+
 				Expect(logger).To(gbytes.Say("btrfs doesn't like you"))
 			})
 		})
 
 		Context("when a RootFS is not provided in the rootfs_provider.Spec", func() {
-			BeforeEach(func() {
-				baseImage = &url.URL{}
-			})
-
 			It("passes the default rootfs to the external-image-manager", func() {
-				Expect(err).ToNot(HaveOccurred())
+				_, _, err := externalImageManager.Create(
+					logger, "hello", rootfs_provider.Spec{},
+				)
+				Expect(err).NotTo(HaveOccurred())
+
 				Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
 				imageManagerCmd := fakeCommandRunner.ExecutedCommands()[0]
 
@@ -238,14 +266,10 @@ var _ = Describe("ExternalImageManager", func() {
 	})
 
 	Describe("Destroy", func() {
-		var err error
-
-		JustBeforeEach(func() {
-			err = externalImageManager.Destroy(logger, "hello", "/store/0/images/123/rootfs")
-		})
-
 		It("uses the correct external-image-manager binary", func() {
-			Expect(err).ToNot(HaveOccurred())
+			Expect(externalImageManager.Destroy(
+				logger, "hello", "/store/0/images/123/rootfs",
+			)).To(Succeed())
 			Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
 			imageManagerCmd := fakeCommandRunner.ExecutedCommands()[0]
 
@@ -254,7 +278,9 @@ var _ = Describe("ExternalImageManager", func() {
 
 		Describe("external-image-manager parameters", func() {
 			It("uses the correct external-image-manager delete command", func() {
-				Expect(err).ToNot(HaveOccurred())
+				Expect(externalImageManager.Destroy(
+					logger, "hello", "/store/0/images/123/rootfs",
+				)).To(Succeed())
 				Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
 				imageManagerCmd := fakeCommandRunner.ExecutedCommands()[0]
 
@@ -262,7 +288,9 @@ var _ = Describe("ExternalImageManager", func() {
 			})
 
 			It("passes the correct image path to delete to/ the external-image-manager", func() {
-				Expect(err).ToNot(HaveOccurred())
+				Expect(externalImageManager.Destroy(
+					logger, "hello", "/store/0/images/123/rootfs",
+				)).To(Succeed())
 				Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
 				imageManagerCmd := fakeCommandRunner.ExecutedCommands()[0]
 
@@ -272,23 +300,24 @@ var _ = Describe("ExternalImageManager", func() {
 
 		Context("when the command fails", func() {
 			BeforeEach(func() {
-				fakeCommandRunner.WhenRunning(fake_command_runner.CommandSpec{
-					Path: "/external-image-manager-bin",
-				}, func(cmd *exec.Cmd) error {
-					cmd.Stderr.Write([]byte("btrfs doesn't like you"))
-					cmd.Stdout.Write([]byte("could not find drax"))
-
-					return errors.New("external-image-manager failure")
-				})
+				fakeCmdRunnerStdout = "could not find drax"
+				fakeCmdRunnerStderr = "btrfs doesn't like you"
+				fakeCmdRunnerErr = errors.New("external-image-manager failure")
 			})
 
 			It("returns an error", func() {
+				err := externalImageManager.Destroy(logger, "hello", "/store/0/images/123/rootfs")
+
 				Expect(err).To(MatchError(ContainSubstring("external image manager destroy failed")))
 				Expect(err).To(MatchError(ContainSubstring("external-image-manager failure")))
 				Expect(err).To(MatchError(ContainSubstring("could not find drax")))
 			})
 
 			It("returns the external-image-manager error output in the error", func() {
+				Expect(externalImageManager.Destroy(
+					logger, "hello", "/store/0/images/123/rootfs",
+				)).NotTo(Succeed())
+
 				Expect(logger).To(gbytes.Say("btrfs doesn't like you"))
 			})
 		})
@@ -311,14 +340,9 @@ var _ = Describe("ExternalImageManager", func() {
 
 		Context("when the command fails", func() {
 			BeforeEach(func() {
-				fakeCommandRunner.WhenRunning(fake_command_runner.CommandSpec{
-					Path: "/external-image-manager-bin",
-				}, func(cmd *exec.Cmd) error {
-					cmd.Stderr.Write([]byte("btrfs doesn't like you"))
-					cmd.Stdout.Write([]byte("could not find drax"))
-
-					return errors.New("external-image-manager failure")
-				})
+				fakeCmdRunnerErr = errors.New("external-image-manager failure")
+				fakeCmdRunnerStderr = "btrfs doesn't like you"
+				fakeCmdRunnerStdout = "could not find drax"
 			})
 
 			It("returns an error", func() {
@@ -336,23 +360,10 @@ var _ = Describe("ExternalImageManager", func() {
 	})
 
 	Describe("Metrics", func() {
-		var (
-			fakeCmdRunnerErr    error
-			fakeCmdRunnerStdout string
-			fakeCmdRunnerStderr string
-		)
 		BeforeEach(func() {
 			fakeCmdRunnerErr = nil
 			fakeCmdRunnerStdout = `{"disk_usage": {"total_bytes_used": 1000, "exclusive_bytes_used": 2000}}`
 			fakeCmdRunnerStderr = ""
-
-			fakeCommandRunner.WhenRunning(fake_command_runner.CommandSpec{
-				Path: "/external-image-manager-bin",
-			}, func(cmd *exec.Cmd) error {
-				cmd.Stdout.Write([]byte(fakeCmdRunnerStdout))
-				cmd.Stderr.Write([]byte(fakeCmdRunnerStderr))
-				return fakeCmdRunnerErr
-			})
 		})
 
 		It("uses the correct external-image-manager binary", func() {

--- a/imageplugin/image.go
+++ b/imageplugin/image.go
@@ -1,0 +1,9 @@
+package imageplugin
+
+type Image struct {
+	Config ImageConfig `json:"config,omitempty"`
+}
+
+type ImageConfig struct {
+	Env []string `json:"Env,omitempty"`
+}


### PR DESCRIPTION
This enables loading environmental variables from the `image.json` when creating images based on a docker image using the `imageplugin`.

https://www.pivotaltracker.com/story/show/133744595