### PR TITLE
Implement image plugin `Metrics` command

### DIFF
--- a/gardener/container.go
+++ b/gardener/container.go
@@ -148,7 +148,12 @@ func (c *container) Metrics() (garden.Metrics, error) {
 		return garden.Metrics{}, err
 	}
 
-	diskMetrics, err := c.volumeCreator.Metrics(c.logger, c.handle)
+	actualContainerSpec, err := c.containerizer.Info(c.logger, c.handle)
+	if err != nil {
+		return garden.Metrics{}, err
+	}
+
+	diskMetrics, err := c.volumeCreator.Metrics(c.logger, c.handle, actualContainerSpec.RootFSPath)
 	if err != nil {
 		return garden.Metrics{}, err
 	}

--- a/gardener/gardener.go
+++ b/gardener/gardener.go
@@ -63,7 +63,7 @@ type Networker interface {
 type VolumeCreator interface {
 	Create(log lager.Logger, handle string, spec rootfs_provider.Spec) (string, []string, error)
 	Destroy(log lager.Logger, handle, rootFSPath string) error
-	Metrics(log lager.Logger, handle string) (garden.ContainerDiskStat, error)
+	Metrics(log lager.Logger, handle, rootFSPath string) (garden.ContainerDiskStat, error)
 	GC(log lager.Logger) error
 }
 

--- a/gardener/gardener_test.go
+++ b/gardener/gardener_test.go
@@ -1317,6 +1317,17 @@ var _ = Describe("Gardener", func() {
 			})
 		})
 
+		Context("when fails to get container info", func() {
+			BeforeEach(func() {
+				containerizer.InfoReturns(gardener.ActualContainerSpec{}, errors.New("banana"))
+			})
+
+			It("returns an error", func() {
+				_, err := container.Metrics()
+				Expect(err).To(MatchError("banana"))
+			})
+		})
+
 		Context("when disk metrics cannot be acquired", func() {
 			BeforeEach(func() {
 				volumeCreator.MetricsReturns(garden.ContainerDiskStat{}, errors.New("banana"))

--- a/gardener/gardenerfakes/fake_volume_creator.go
+++ b/gardener/gardenerfakes/fake_volume_creator.go
@@ -33,11 +33,12 @@ type FakeVolumeCreator struct {
 	destroyReturns struct {
 		result1 error
 	}
-	MetricsStub        func(log lager.Logger, handle string) (garden.ContainerDiskStat, error)
+	MetricsStub        func(log lager.Logger, handle, rootFSPath string) (garden.ContainerDiskStat, error)
 	metricsMutex       sync.RWMutex
 	metricsArgsForCall []struct {
-		log    lager.Logger
-		handle string
+		log        lager.Logger
+		handle     string
+		rootFSPath string
 	}
 	metricsReturns struct {
 		result1 garden.ContainerDiskStat
@@ -127,16 +128,17 @@ func (fake *FakeVolumeCreator) DestroyReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *FakeVolumeCreator) Metrics(log lager.Logger, handle string) (garden.ContainerDiskStat, error) {
+func (fake *FakeVolumeCreator) Metrics(log lager.Logger, handle string, rootFSPath string) (garden.ContainerDiskStat, error) {
 	fake.metricsMutex.Lock()
 	fake.metricsArgsForCall = append(fake.metricsArgsForCall, struct {
-		log    lager.Logger
-		handle string
-	}{log, handle})
-	fake.recordInvocation("Metrics", []interface{}{log, handle})
+		log        lager.Logger
+		handle     string
+		rootFSPath string
+	}{log, handle, rootFSPath})
+	fake.recordInvocation("Metrics", []interface{}{log, handle, rootFSPath})
 	fake.metricsMutex.Unlock()
 	if fake.MetricsStub != nil {
-		return fake.MetricsStub(log, handle)
+		return fake.MetricsStub(log, handle, rootFSPath)
 	} else {
 		return fake.metricsReturns.result1, fake.metricsReturns.result2
 	}
@@ -148,10 +150,10 @@ func (fake *FakeVolumeCreator) MetricsCallCount() int {
 	return len(fake.metricsArgsForCall)
 }
 
-func (fake *FakeVolumeCreator) MetricsArgsForCall(i int) (lager.Logger, string) {
+func (fake *FakeVolumeCreator) MetricsArgsForCall(i int) (lager.Logger, string, string) {
 	fake.metricsMutex.RLock()
 	defer fake.metricsMutex.RUnlock()
-	return fake.metricsArgsForCall[i].log, fake.metricsArgsForCall[i].handle
+	return fake.metricsArgsForCall[i].log, fake.metricsArgsForCall[i].handle, fake.metricsArgsForCall[i].rootFSPath
 }
 
 func (fake *FakeVolumeCreator) MetricsReturns(result1 garden.ContainerDiskStat, result2 error) {

--- a/gardener/noop_volume_creator.go
+++ b/gardener/noop_volume_creator.go
@@ -20,7 +20,7 @@ func (NoopVolumeCreator) Destroy(lager.Logger, string, string) error {
 	return nil
 }
 
-func (NoopVolumeCreator) Metrics(lager.Logger, string) (garden.ContainerDiskStat, error) {
+func (NoopVolumeCreator) Metrics(lager.Logger, string, string) (garden.ContainerDiskStat, error) {
 	return garden.ContainerDiskStat{}, nil
 }
 

--- a/gardener/noop_volume_creator_test.go
+++ b/gardener/noop_volume_creator_test.go
@@ -36,7 +36,7 @@ var _ = Describe("NoopVolumeCreator", func() {
 
 	Describe("Metrics", func() {
 		It("successfully returns an empty set of metrics", func() {
-			Expect(volumeCreator.Metrics(logger, "some-handle")).To(Equal(garden.ContainerDiskStat{}))
+			Expect(volumeCreator.Metrics(logger, "some-handle", "rootfs")).To(Equal(garden.ContainerDiskStat{}))
 		})
 	})
 

--- a/imageplugin/external_image_manager.go
+++ b/imageplugin/external_image_manager.go
@@ -2,6 +2,7 @@ package imageplugin
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os/exec"
@@ -113,12 +114,33 @@ func (p *ExternalImageManager) Destroy(log lager.Logger, handle, rootfs string) 
 	return nil
 }
 
-func (p *ExternalImageManager) Metrics(log lager.Logger, handle string) (garden.ContainerDiskStat, error) {
-	log = log.Session("image-plugin-metrics")
+func (p *ExternalImageManager) Metrics(log lager.Logger, _, rootfs string) (garden.ContainerDiskStat, error) {
+	log = log.Session("image-plugin-metrics", lager.Data{"rootfs": rootfs})
 	log.Debug("start")
 	defer log.Debug("end")
 
-	return garden.ContainerDiskStat{}, nil
+	imagePath := filepath.Dir(rootfs)
+	cmd := exec.Command(p.binPath, "metrics", imagePath)
+	errBuffer := bytes.NewBuffer([]byte{})
+	cmd.Stderr = errBuffer
+	outBuffer := bytes.NewBuffer([]byte{})
+	cmd.Stdout = outBuffer
+
+	if err := p.commandRunner.Run(cmd); err != nil {
+		logData := lager.Data{"action": "metrics", "stderr": errBuffer.String()}
+		log.Error("external-image-manager-result", err, logData)
+		return garden.ContainerDiskStat{}, fmt.Errorf("external image manager metrics failed: %s", err)
+	}
+
+	var metrics map[string]map[string]uint64
+	if err := json.NewDecoder(outBuffer).Decode(&metrics); err != nil {
+		return garden.ContainerDiskStat{}, fmt.Errorf("parsing metrics: %s", err)
+	}
+
+	return garden.ContainerDiskStat{
+		TotalBytesUsed:     metrics["disk_usage"]["total_bytes_used"],
+		ExclusiveBytesUsed: metrics["disk_usage"]["exclusive_bytes_used"],
+	}, nil
 }
 
 func (p *ExternalImageManager) GC(log lager.Logger) error {

--- a/imageplugin/external_image_manager.go
+++ b/imageplugin/external_image_manager.go
@@ -129,7 +129,7 @@ func (p *ExternalImageManager) Metrics(log lager.Logger, _, rootfs string) (gard
 	if err := p.commandRunner.Run(cmd); err != nil {
 		logData := lager.Data{"action": "metrics", "stderr": errBuffer.String()}
 		log.Error("external-image-manager-result", err, logData)
-		return garden.ContainerDiskStat{}, fmt.Errorf("external image manager metrics failed: %s", err)
+		return garden.ContainerDiskStat{}, fmt.Errorf("external image manager metrics failed: %s (%s)", outBuffer.String(), err)
 	}
 
 	var metrics map[string]map[string]uint64

--- a/imageplugin/external_image_manager_test.go
+++ b/imageplugin/external_image_manager_test.go
@@ -380,9 +380,11 @@ var _ = Describe("ExternalImageManager", func() {
 
 		Context("when the image plugin fails", func() {
 			It("returns an error", func() {
+				fakeCmdRunnerStdout = "could not find drax"
 				fakeCmdRunnerErr = errors.New("failed to get metrics")
 				_, err := externalImageManager.Metrics(logger, "", "/store/0/bundles/123/rootfs")
 				Expect(err).To(MatchError(ContainSubstring("failed to get metrics")))
+				Expect(err).To(MatchError(ContainSubstring("could not find drax")))
 			})
 		})
 

--- a/imageplugin/external_image_manager_test.go
+++ b/imageplugin/external_image_manager_test.go
@@ -330,4 +330,68 @@ var _ = Describe("ExternalImageManager", func() {
 			})
 		})
 	})
+
+	Describe("Metrics", func() {
+		var (
+			fakeCmdRunnerErr    error
+			fakeCmdRunnerStdout string
+			fakeCmdRunnerStderr string
+		)
+		BeforeEach(func() {
+			fakeCmdRunnerErr = nil
+			fakeCmdRunnerStdout = `{"disk_usage": {"total_bytes_used": 1000, "exclusive_bytes_used": 2000}}`
+			fakeCmdRunnerStderr = ""
+
+			fakeCommandRunner.WhenRunning(fake_command_runner.CommandSpec{
+				Path: "/external-image-manager-bin",
+			}, func(cmd *exec.Cmd) error {
+				cmd.Stdout.Write([]byte(fakeCmdRunnerStdout))
+				cmd.Stderr.Write([]byte(fakeCmdRunnerStderr))
+				return fakeCmdRunnerErr
+			})
+		})
+
+		It("uses the correct external-image-manager binary", func() {
+			_, err := externalImageManager.Metrics(logger, "", "/store/0/bundles/123/rootfs")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
+			imageManagerCmd := fakeCommandRunner.ExecutedCommands()[0]
+
+			Expect(imageManagerCmd.Path).To(Equal("/external-image-manager-bin"))
+		})
+
+		It("calls external-image-manager with the correct arguments", func() {
+			_, err := externalImageManager.Metrics(logger, "", "/store/0/bundles/123/rootfs")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(fakeCommandRunner.ExecutedCommands())).To(Equal(1))
+			imageManagerCmd := fakeCommandRunner.ExecutedCommands()[0]
+
+			Expect(imageManagerCmd.Args[1]).To(Equal("metrics"))
+			Expect(imageManagerCmd.Args[2]).To(Equal("/store/0/bundles/123"))
+		})
+
+		It("returns the correct ContainerDiskStat", func() {
+			stats, err := externalImageManager.Metrics(logger, "", "/store/0/bundles/123/rootfs")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(stats.TotalBytesUsed).To(Equal(uint64(1000)))
+			Expect(stats.ExclusiveBytesUsed).To(Equal(uint64(2000)))
+		})
+
+		Context("when the image plugin fails", func() {
+			It("returns an error", func() {
+				fakeCmdRunnerErr = errors.New("failed to get metrics")
+				_, err := externalImageManager.Metrics(logger, "", "/store/0/bundles/123/rootfs")
+				Expect(err).To(MatchError(ContainSubstring("failed to get metrics")))
+			})
+		})
+
+		Context("when the image plugin output parsing fails", func() {
+			It("returns an error", func() {
+				fakeCmdRunnerStdout = `{"silly" "json":"formating}"}}"`
+				_, err := externalImageManager.Metrics(logger, "", "/store/0/bundles/123/rootfs")
+				Expect(err).To(MatchError(ContainSubstring("parsing metrics")))
+			})
+		})
+	})
 })


### PR DESCRIPTION
Adds ImagePlugin `Metrics` implementation.

* The `VolumeCreator` interface had to be updated to contain the rootfs path.

[#133928963]
Part of https://www.pivotaltracker.com/story/show/133928963

Signed-off-by: Claudia Beresford <cberesford@pivotal.io>