### PR TITLE
Relog imageplugin logs into the garden logger

### DIFF
--- a/imageplugin/external_image_manager_test.go
+++ b/imageplugin/external_image_manager_test.go
@@ -12,9 +12,10 @@ import (
 
 	"code.cloudfoundry.org/garden-shed/rootfs_provider"
 	"code.cloudfoundry.org/guardian/imageplugin"
-	"code.cloudfoundry.org/lager/lagertest"
+	"code.cloudfoundry.org/lager"
 	"github.com/cloudfoundry/gunk/command_runner/fake_command_runner"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/st3v/glager"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -24,7 +25,7 @@ import (
 var _ = Describe("ExternalImageManager", func() {
 	var (
 		fakeCommandRunner    *fake_command_runner.FakeCommandRunner
-		logger               *lagertest.TestLogger
+		logger               lager.Logger
 		externalImageManager *imageplugin.ExternalImageManager
 		baseImage            *url.URL
 		idMappings           []specs.LinuxIDMapping
@@ -39,7 +40,7 @@ var _ = Describe("ExternalImageManager", func() {
 		fakeCmdRunnerStderr = ""
 		fakeCmdRunnerErr = nil
 
-		logger = lagertest.NewTestLogger("external-image-manager")
+		logger = glager.NewLogger("external-image-manager")
 		fakeCommandRunner = fake_command_runner.New()
 
 		idMappings = []specs.LinuxIDMapping{
@@ -282,7 +283,6 @@ var _ = Describe("ExternalImageManager", func() {
 		Context("when the command fails", func() {
 			BeforeEach(func() {
 				fakeCmdRunnerStdout = "could not find drax"
-				fakeCmdRunnerStderr = "btrfs doesn't like you"
 				fakeCmdRunnerErr = errors.New("external-image-manager failure")
 			})
 
@@ -306,7 +306,7 @@ var _ = Describe("ExternalImageManager", func() {
 				)
 				Expect(err).To(HaveOccurred())
 
-				Expect(logger).To(gbytes.Say("btrfs doesn't like you"))
+				Expect(logger).To(gbytes.Say("could not find drax"))
 			})
 		})
 
@@ -361,7 +361,6 @@ var _ = Describe("ExternalImageManager", func() {
 		Context("when the command fails", func() {
 			BeforeEach(func() {
 				fakeCmdRunnerStdout = "could not find drax"
-				fakeCmdRunnerStderr = "btrfs doesn't like you"
 				fakeCmdRunnerErr = errors.New("external-image-manager failure")
 			})
 
@@ -378,7 +377,7 @@ var _ = Describe("ExternalImageManager", func() {
 					logger, "hello", "/store/0/images/123/rootfs",
 				)).NotTo(Succeed())
 
-				Expect(logger).To(gbytes.Say("btrfs doesn't like you"))
+				Expect(logger).To(gbytes.Say("could not find drax"))
 			})
 		})
 	})
@@ -401,7 +400,6 @@ var _ = Describe("ExternalImageManager", func() {
 		Context("when the command fails", func() {
 			BeforeEach(func() {
 				fakeCmdRunnerErr = errors.New("external-image-manager failure")
-				fakeCmdRunnerStderr = "btrfs doesn't like you"
 				fakeCmdRunnerStdout = "could not find drax"
 			})
 
@@ -414,7 +412,7 @@ var _ = Describe("ExternalImageManager", func() {
 
 			It("forwards the external-image-manager error output", func() {
 				externalImageManager.GC(logger)
-				Expect(logger).To(gbytes.Say("btrfs doesn't like you"))
+				Expect(logger).To(gbytes.Say("could not find drax"))
 			})
 		})
 	})
@@ -468,6 +466,125 @@ var _ = Describe("ExternalImageManager", func() {
 				fakeCmdRunnerStdout = `{"silly" "json":"formating}"}}"`
 				_, err := externalImageManager.Metrics(logger, "", "/store/0/bundles/123/rootfs")
 				Expect(err).To(MatchError(ContainSubstring("parsing metrics")))
+			})
+		})
+	})
+
+	Describe("logging", func() {
+		BeforeEach(func() {
+			buffer := gbytes.NewBuffer()
+			externalLogger := lager.NewLogger("external-plugin")
+			externalLogger.RegisterSink(lager.NewWriterSink(buffer, lager.DEBUG))
+			externalLogger.Debug("debug-message", lager.Data{"type": "debug"})
+			externalLogger.Info("info-message", lager.Data{"type": "info"})
+			externalLogger.Error("error-message", errors.New("failed!"), lager.Data{"type": "error"})
+
+			fakeCmdRunnerStderr = string(buffer.Contents())
+		})
+
+		Context("Create", func() {
+
+			It("relogs the image plugin logs", func() {
+				_, _, err := externalImageManager.Create(
+					logger, "hello", rootfs_provider.Spec{
+						RootFS: baseImage,
+					},
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(logger).To(glager.ContainSequence(
+					glager.Debug(
+						glager.Message("external-image-manager.image-plugin-create.external-plugin.debug-message"),
+						glager.Data("type", "debug"),
+					),
+					glager.Info(
+						glager.Message("external-image-manager.image-plugin-create.external-plugin.info-message"),
+						glager.Data("type", "info"),
+					),
+					glager.Error(
+						errors.New("failed!"),
+						glager.Message("external-image-manager.image-plugin-create.external-plugin.error-message"),
+						glager.Data("type", "error"),
+					),
+				))
+			})
+		})
+
+		Context("Destroy", func() {
+			It("relogs the image plugin logs", func() {
+				err := externalImageManager.Destroy(
+					logger, "hello", "/store/0/images/123/rootfs",
+				)
+
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(logger).To(glager.ContainSequence(
+					glager.Debug(
+						glager.Message("external-image-manager.image-plugin-destroy.external-plugin.debug-message"),
+						glager.Data("type", "debug"),
+					),
+					glager.Info(
+						glager.Message("external-image-manager.image-plugin-destroy.external-plugin.info-message"),
+						glager.Data("type", "info"),
+					),
+					glager.Error(
+						errors.New("failed!"),
+						glager.Message("external-image-manager.image-plugin-destroy.external-plugin.error-message"),
+						glager.Data("type", "error"),
+					),
+				))
+			})
+		})
+
+		Context("Metrics", func() {
+			It("relogs the image plugin logs", func() {
+				fakeCmdRunnerStdout = `{}`
+
+				_, err := externalImageManager.Metrics(
+					logger, "hello", "/store/0/images/123/rootfs",
+				)
+
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(logger).To(glager.ContainSequence(
+					glager.Debug(
+						glager.Message("external-image-manager.image-plugin-metrics.external-plugin.debug-message"),
+						glager.Data("type", "debug"),
+					),
+					glager.Info(
+						glager.Message("external-image-manager.image-plugin-metrics.external-plugin.info-message"),
+						glager.Data("type", "info"),
+					),
+					glager.Error(
+						errors.New("failed!"),
+						glager.Message("external-image-manager.image-plugin-metrics.external-plugin.error-message"),
+						glager.Data("type", "error"),
+					),
+				))
+			})
+		})
+
+		Context("GC", func() {
+			It("relogs the image plugin logs", func() {
+				err := externalImageManager.GC(logger)
+
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(logger).To(glager.ContainSequence(
+					glager.Debug(
+						glager.Message("external-image-manager.image-plugin-gc.external-plugin.debug-message"),
+						glager.Data("type", "debug"),
+					),
+					glager.Info(
+						glager.Message("external-image-manager.image-plugin-gc.external-plugin.info-message"),
+						glager.Data("type", "info"),
+					),
+					glager.Error(
+						errors.New("failed!"),
+						glager.Message("external-image-manager.image-plugin-gc.external-plugin.error-message"),
+						glager.Data("type", "error"),
+					),
+				))
 			})
 		})
 	})


### PR DESCRIPTION
* Imageplugin logs will be relogged (namespaced) in the garden logger.
* Error messages will include the image plugin stdout instead of the
  stderr (stderr is for logs only).
* Add 2 new GO dependencies.

[finishes #133833213]

Signed-off-by: Claudia Beresford <cberesford@pivotal.io>