### PR TITLE
Allow winc.exe to be used as the runtime_plugin

### DIFF
--- a/guardiancmd/command.go
+++ b/guardiancmd/command.go
@@ -606,21 +606,9 @@ func (cmd *ServerCommand) wireContainerizer(log lager.Logger,
 		),
 	)
 
-	mounts := []specs.Mount{
-		{Type: "sysfs", Source: "sysfs", Destination: "/sys", Options: []string{"nosuid", "noexec", "nodev", "ro"}},
-		{Type: "tmpfs", Source: "tmpfs", Destination: "/dev/shm"},
-		{Type: "devpts", Source: "devpts", Destination: "/dev/pts",
-			Options: []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620"}},
-		{Type: "bind", Source: cmd.Bin.Init.Path(), Destination: "/tmp/garden-init", Options: []string{"bind"}},
-	}
-
-	privilegedMounts := append(mounts,
-		specs.Mount{Type: "proc", Source: "proc", Destination: "/proc", Options: []string{"nosuid", "noexec", "nodev"}},
-	)
-
-	unprivilegedMounts := append(mounts,
-		specs.Mount{Type: "proc", Source: "proc", Destination: "/proc", Options: []string{"nosuid", "noexec", "nodev"}},
-	)
+	mounts := defaultBindMounts(cmd.Bin.Init.Path())
+	privilegedMounts := append(mounts, privilegedMounts()...)
+	unprivilegedMounts := append(mounts, unprivilegedMounts()...)
 
 	rwm := "rwm"
 	character := "c"

--- a/guardiancmd/command_windows.go
+++ b/guardiancmd/command_windows.go
@@ -12,6 +12,7 @@ import (
 	"code.cloudfoundry.org/guardian/rundmc/execrunner"
 	"code.cloudfoundry.org/guardian/rundmc/runrunc"
 	"code.cloudfoundry.org/lager"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 type NoopStarter struct{}
@@ -65,4 +66,16 @@ func (fileWriter) WriteFile(path string, contents []byte, mode os.FileMode) erro
 
 func (cmd *ServerCommand) wireExecPreparer() runrunc.ExecPreparer {
 	return &runrunc.WindowsExecPreparer{}
+}
+
+func defaultBindMounts(binInitPath string) []specs.Mount {
+	return []specs.Mount{}
+}
+
+func privilegedMounts() []specs.Mount {
+	return []specs.Mount{}
+}
+
+func unprivilegedMounts() []specs.Mount {
+	return []specs.Mount{}
 }

--- a/rundmc/runrunc/create.go
+++ b/rundmc/runrunc/create.go
@@ -87,6 +87,7 @@ func processLogs(log lager.Logger, logFilePath string, upstreamErr error) error 
 
 		return fmt.Errorf("runc create: open log file '%s': %s", logFilePath, err)
 	}
+	defer logReader.Close()
 
 	buff, readErr := ioutil.ReadAll(logReader)
 	if readErr != nil {


### PR DESCRIPTION
These changes enable creating and destroying containers with [`winc`](https://github.com/cloudfoundry-incubator/winc) used as the runtime plugin.

* Close logfile after reading
* Do not write files in /etc on windows