### PR TITLE
backfile runtime plugin stdout, stderr tests

### DIFF
--- a/gqt/cmd/fake_runtime_plugin/main.go
+++ b/gqt/cmd/fake_runtime_plugin/main.go
@@ -150,6 +150,14 @@ var ExecCommand = cli.Command{
 		exitCode, err := strconv.Atoi(exitCodeStr)
 		mustNot(err)
 
+		stdoutStr := procSpec.Args[2]
+		_, err = fmt.Fprintln(os.Stdout, stdoutStr)
+		mustNot(err)
+
+		stderrStr := procSpec.Args[3]
+		_, err = fmt.Fprintln(os.Stderr, stderrStr)
+		mustNot(err)
+
 		// To satisfy dadoo's requirement that the runtime plugin fork SOMETHING
 		childCmd := exec.Command(os.Args[0], "child", "--exitcode", exitCodeStr)
 		must(childCmd.Start())


### PR DESCRIPTION
This should backfill the runtime plugin tests to ensure that stdout and stderr are properly retrieved from the runtime plugin.

(Let me know if you want to move the `Context` or `It` block to another place or change the descriptions)