### PR TITLE
Add Windows bundle

### DIFF
--- a/guardiancmd/command.go
+++ b/guardiancmd/command.go
@@ -685,6 +685,7 @@ func (cmd *ServerCommand) wireContainerizer(log lager.Logger,
 		bundlerules.Mounts{},
 		bundlerules.Env{},
 		bundlerules.Hostname{},
+		bundlerules.Windows{},
 	}
 	bundleRules = append(bundleRules, osSpecificBundleRules()...)
 

--- a/rundmc/bundlerules/windows.go
+++ b/rundmc/bundlerules/windows.go
@@ -1,0 +1,16 @@
+package bundlerules
+
+import (
+	"code.cloudfoundry.org/guardian/gardener"
+	"code.cloudfoundry.org/guardian/rundmc/goci"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+type Windows struct{}
+
+func (w Windows) Apply(bndl goci.Bndl, spec gardener.DesiredContainerSpec, _ string) (goci.Bndl, error) {
+	limit := uint64(spec.Limits.Memory.LimitInBytes)
+	bndl = bndl.WithWindowsMemoryLimit(specs.WindowsMemoryResources{Limit: &limit})
+
+	return bndl, nil
+}

--- a/rundmc/bundlerules/windows_test.go
+++ b/rundmc/bundlerules/windows_test.go
@@ -1,0 +1,24 @@
+package bundlerules_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"code.cloudfoundry.org/garden"
+	"code.cloudfoundry.org/guardian/gardener"
+	"code.cloudfoundry.org/guardian/rundmc/bundlerules"
+	"code.cloudfoundry.org/guardian/rundmc/goci"
+)
+
+var _ = Describe("LimitsRule", func() {
+	It("sets the correct memory limit in bundle resources", func() {
+		newBndl, err := bundlerules.Windows{}.Apply(goci.Bundle(), gardener.DesiredContainerSpec{
+			Limits: garden.Limits{
+				Memory: garden.MemoryLimits{LimitInBytes: 4096},
+			},
+		}, "not-needed-path")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(*(newBndl.Spec.Windows.Resources.Memory.Limit)).To(BeNumerically("==", 4096))
+	})
+})

--- a/rundmc/goci/bundle.go
+++ b/rundmc/goci/bundle.go
@@ -13,6 +13,9 @@ func Bundle() Bndl {
 		Spec: specs.Spec{
 			Version: "1.0.0-rc6",
 			Linux:   &specs.Linux{},
+			Windows: &specs.Windows{
+				LayerFolders: []string{"ignored-for-now"},
+			},
 			Process: &specs.Process{
 				ConsoleSize: &specs.Box{},
 			},
@@ -74,6 +77,10 @@ func (b Bndl) Resources() *specs.LinuxResources {
 	return b.Spec.Linux.Resources
 }
 
+func (b Bndl) WindowsResources() *specs.WindowsResources {
+	return b.Spec.Windows.Resources
+}
+
 func (b Bndl) WithBlockIO(blockIO specs.LinuxBlockIO) Bndl {
 	resources := b.Resources()
 	if resources == nil {
@@ -106,6 +113,18 @@ func (b Bndl) WithMemoryLimit(limit specs.LinuxMemory) Bndl {
 
 	resources.Memory = &limit
 	b.CloneLinux().Spec.Linux.Resources = resources
+
+	return b
+}
+
+func (b Bndl) WithWindowsMemoryLimit(limit specs.WindowsMemoryResources) Bndl {
+	resources := b.WindowsResources()
+	if resources == nil {
+		resources = &specs.WindowsResources{}
+	}
+
+	resources.Memory = &limit
+	b.CloneWindows().Spec.Windows.Resources = resources
 
 	return b
 }
@@ -254,6 +273,11 @@ func (b *Bndl) CloneLinux() Bndl {
 	b.Spec.Linux = &l
 	return *b
 }
+func (b *Bndl) CloneWindows() Bndl {
+	l := copyWindows(*b.Spec.Windows)
+	b.Spec.Windows = &l
+	return *b
+}
 
 func (b *Bndl) CloneProcess() Bndl {
 	l := (*b.Spec.Process)
@@ -262,5 +286,9 @@ func (b *Bndl) CloneProcess() Bndl {
 }
 
 func copy(l specs.Linux) specs.Linux {
+	return l
+}
+
+func copyWindows(l specs.Windows) specs.Windows {
 	return l
 }

--- a/rundmc/goci/bundle_test.go
+++ b/rundmc/goci/bundle_test.go
@@ -218,6 +218,26 @@ var _ = Describe("Bundle", func() {
 		})
 	})
 
+	Describe("WithWindowsMemoryLimit", func() {
+		var limit uint64
+		var mem specs.WindowsMemoryResources
+
+		BeforeEach(func() {
+			limit = 500
+			mem = specs.WindowsMemoryResources{Limit: &limit}
+			returnedBundle = initialBundle.WithWindowsMemoryLimit(mem)
+		})
+
+		It("returns a bundle with the windows memory limit", func() {
+			Expect(*(returnedBundle.WindowsResources().Memory)).To(Equal(mem))
+		})
+
+		It("does not modify the original bundle", func() {
+			Expect(returnedBundle).NotTo(Equal(initialBundle))
+			Expect(initialBundle.Resources()).To(BeNil())
+		})
+	})
+
 	Describe("WithCPUShares", func() {
 		var shares uint64 = 10
 


### PR DESCRIPTION
cf push should respect memory limits when running on winc.
`spec.Windows` is used by winc to apply mem limits.

Note that the Windows.LayerFolders object in the spec is mandatory, and winc ignores it for now. 

[#147778393]

Signed-off-by: Amin Jamali <ajamali@pivotal.io>