### PR TITLE
Allow RootFS Propagation all the way down to runc

### DIFF
--- a/gardener/gardener.go
+++ b/gardener/gardener.go
@@ -124,6 +124,9 @@ type DesiredContainerSpec struct {
 	// Path to the Root Filesystem for the container
 	RootFSPath string
 
+	// RootFS propagation rule for the container
+	RootFSPropagation string
+
 	// Container hostname
 	Hostname string
 
@@ -283,6 +286,7 @@ func (g *Gardener) Create(spec garden.ContainerSpec) (ctr garden.Container, err 
 	if err := g.Containerizer.Create(log, DesiredContainerSpec{
 		Handle:                 spec.Handle,
 		RootFSPath:             desiredImageSpec.RootFS,
+		RootFSPropagation:      spec.RootFSPropagation,
 		Hostname:               spec.Handle,
 		Privileged:             spec.Privileged,
 		BindMounts:             spec.BindMounts,

--- a/gardener/gardener_test.go
+++ b/gardener/gardener_test.go
@@ -149,6 +149,20 @@ var _ = Describe("Gardener", func() {
 			})
 		})
 
+		Context("when passing a rootfs propagation rule", func() {
+			It("should pass the the rootfs propagation to the containerizer", func() {
+				_, err := gdnr.Create(garden.ContainerSpec{
+					RootFSPropagation: "shared",
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(containerizer.CreateCallCount()).To(Equal(1))
+
+				_, spec := containerizer.CreateArgsForCall(0)
+				Expect(spec.RootFSPropagation).To(Equal("shared"))
+			})
+		})
+
 		Context("when passing an ImageRef", func() {
 			Context("when parsing the rootfs path fails", func() {
 				It("should return an error", func() {

--- a/guardiancmd/command.go
+++ b/guardiancmd/command.go
@@ -677,6 +677,7 @@ func (cmd *ServerCommand) wireContainerizer(log lager.Logger,
 			ContainerRootGID: gidMappings.Map(0),
 			MkdirChown:       chrootMkdir,
 		},
+		bundlerules.RootFSPropagation{},
 		bundlerules.Limits{
 			CpuQuotaPerShare: cmd.Limits.CpuQuotaPerShare,
 			TCPMemoryLimit:   int64(cmd.Limits.TCPMemoryLimit),

--- a/rundmc/bundlerules/rootfs_propagation.go
+++ b/rundmc/bundlerules/rootfs_propagation.go
@@ -1,0 +1,14 @@
+package bundlerules
+
+import (
+	"code.cloudfoundry.org/guardian/gardener"
+	"code.cloudfoundry.org/guardian/rundmc/goci"
+)
+
+type RootFSPropagation struct {
+}
+
+func (l RootFSPropagation) Apply(bndl goci.Bndl, spec gardener.DesiredContainerSpec, _ string) (goci.Bndl, error) {
+	rootfsPropagation := spec.RootFSPropagation
+	return bndl.WithRootFSPropagation(rootfsPropagation), nil
+}

--- a/rundmc/bundlerules/rootfs_propagation_test.go
+++ b/rundmc/bundlerules/rootfs_propagation_test.go
@@ -1,0 +1,20 @@
+package bundlerules_test
+
+import (
+	"code.cloudfoundry.org/guardian/gardener"
+	"code.cloudfoundry.org/guardian/rundmc/bundlerules"
+	"code.cloudfoundry.org/guardian/rundmc/goci"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RootFSPropagation", func() {
+	It("sets the correct rootfs propagation in the bundle", func() {
+		newBndl, err := bundlerules.RootFSPropagation{}.Apply(goci.Bundle(), gardener.DesiredContainerSpec{
+			RootFSPropagation: "banana",
+		}, "not-needed-path")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(newBndl.RootFSPropagation()).To(Equal("banana"))
+	})
+})

--- a/rundmc/goci/bundle.go
+++ b/rundmc/goci/bundle.go
@@ -62,6 +62,15 @@ func (b Bndl) WithRootFS(absolutePath string) Bndl {
 	return b
 }
 
+func (b Bndl) RootFSPropagation() string {
+	return b.Spec.Linux.RootfsPropagation
+}
+
+func (b Bndl) WithRootFSPropagation(rootfsPropagation string) Bndl {
+	b.Spec.Linux.RootfsPropagation = rootfsPropagation
+	return b
+}
+
 // GetRootfsPath returns the path to the rootfs of this bundle. Nothing is modified
 func (b Bndl) RootFS() string {
 	return b.Spec.Root.Path

--- a/rundmc/goci/bundle_test.go
+++ b/rundmc/goci/bundle_test.go
@@ -26,6 +26,13 @@ var _ = Describe("Bundle", func() {
 		})
 	})
 
+	Describe("WithRootFSPropagation", func() {
+		It("sets the RootFSPropagation in the bundle", func() {
+			returnedBundle := initialBundle.WithRootFSPropagation("rshared")
+			Expect(returnedBundle.RootFSPropagation()).To(Equal("rshared"))
+		})
+	})
+
 	Describe("WithCapabilities", func() {
 		It("adds capabilities to the bundle", func() {
 			returnedBundle := initialBundle.WithCapabilities("growtulips", "waterspuds")


### PR DESCRIPTION
This enables nested mounts within the bind mounts a container asks for. Currently a problem with the BOSH Warden CPI using garden-runc since it cannot properly use persistent disks due to this limitation.

Depends on https://github.com/cloudfoundry/garden/pull/57

I tried to write a gqt for this but couldn't find a good way to do so. It seems that the fact that the test is running in a container in concourse that is setup without this propagation prevents me from doing it so. Happy to hear otherwise though.