### PR TITLE
Pass Windows LayerFolders from image plugin to runtime plugin

### DIFF
--- a/gardener/gardener.go
+++ b/gardener/gardener.go
@@ -11,6 +11,7 @@ import (
 
 	"code.cloudfoundry.org/garden"
 	"code.cloudfoundry.org/garden-shed/rootfs_spec"
+	"code.cloudfoundry.org/guardian/rundmc/goci"
 	"code.cloudfoundry.org/lager"
 )
 
@@ -77,6 +78,7 @@ type DesiredImageSpec struct {
 	RootFS string        `json:"rootfs,omitempty"`
 	Mounts []specs.Mount `json:"mounts,omitempty"`
 	Image  Image         `json:"image,omitempty"`
+	specs.Spec
 }
 
 type Image struct {
@@ -139,6 +141,8 @@ type DesiredContainerSpec struct {
 	Limits garden.Limits
 
 	Env []string
+
+	BaseConfig goci.Bndl
 }
 
 type ActualContainerSpec struct {
@@ -289,6 +293,7 @@ func (g *Gardener) Create(spec garden.ContainerSpec) (ctr garden.Container, err 
 		DesiredImageSpecMounts: desiredImageSpec.Mounts,
 		Limits:                 spec.Limits,
 		Env:                    append(desiredImageSpec.Image.Config.Env, spec.Env...),
+		BaseConfig:             goci.Bndl{Spec: desiredImageSpec.Spec},
 	}); err != nil {
 		return nil, err
 	}

--- a/gardener/gardener_test.go
+++ b/gardener/gardener_test.go
@@ -410,6 +410,27 @@ var _ = Describe("Gardener", func() {
 			}}))
 		})
 
+		It("passes the base runtime config from the DesiredImageSpec to the containerizer", func() {
+			volumeCreator.CreateReturns(gardener.DesiredImageSpec{
+				Spec: specs.Spec{
+					Root: &specs.Root{
+						Path: "banana",
+					},
+					Windows: &specs.Windows{
+						LayerFolders: []string{"layer-1", "layer-2"},
+					},
+				},
+			}, nil)
+
+			_, err := gdnr.Create(garden.ContainerSpec{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(containerizer.CreateCallCount()).To(Equal(1))
+			_, spec := containerizer.CreateArgsForCall(0)
+			Expect(spec.BaseConfig.Spec.Root.Path).To(Equal("banana"))
+			Expect(spec.BaseConfig.Spec.Windows.LayerFolders).To(Equal([]string{"layer-1", "layer-2"}))
+		})
+
 		Context("when environment variables are specified", func() {
 			It("passes into the containerizer", func() {
 				_, err := gdnr.Create(garden.ContainerSpec{

--- a/rundmc/bundlerules/windows.go
+++ b/rundmc/bundlerules/windows.go
@@ -11,6 +11,9 @@ type Windows struct{}
 func (w Windows) Apply(bndl goci.Bndl, spec gardener.DesiredContainerSpec, _ string) (goci.Bndl, error) {
 	limit := uint64(spec.Limits.Memory.LimitInBytes)
 	bndl = bndl.WithWindowsMemoryLimit(specs.WindowsMemoryResources{Limit: &limit})
+	if spec.BaseConfig.Spec.Windows != nil {
+		bndl = bndl.WithWindowsLayerFolders(spec.BaseConfig.Spec.Windows.LayerFolders)
+	}
 
 	return bndl, nil
 }

--- a/rundmc/bundlerules/windows_test.go
+++ b/rundmc/bundlerules/windows_test.go
@@ -3,6 +3,7 @@ package bundlerules_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 
 	"code.cloudfoundry.org/garden"
 	"code.cloudfoundry.org/guardian/gardener"
@@ -20,5 +21,21 @@ var _ = Describe("LimitsRule", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(*(newBndl.Spec.Windows.Resources.Memory.Limit)).To(BeNumerically("==", 4096))
+	})
+
+	It("sets the correct layerfolders in bundle", func() {
+		desiredLayerFolders := []string{"layer-1", "layer-0"}
+		newBndl, err := bundlerules.Windows{}.Apply(goci.Bundle(), gardener.DesiredContainerSpec{
+			BaseConfig: goci.Bndl{
+				Spec: specs.Spec{
+					Windows: &specs.Windows{
+						LayerFolders: desiredLayerFolders,
+					},
+				},
+			},
+		}, "not-needed-path")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(newBndl.Spec.Windows.LayerFolders).To(Equal(desiredLayerFolders))
 	})
 })

--- a/rundmc/goci/bundle.go
+++ b/rundmc/goci/bundle.go
@@ -14,7 +14,7 @@ func Bundle() Bndl {
 			Version: "1.0.0-rc6",
 			Linux:   &specs.Linux{},
 			Windows: &specs.Windows{
-				LayerFolders: []string{"ignored-for-now"},
+				LayerFolders: []string{},
 			},
 			Process: &specs.Process{
 				ConsoleSize: &specs.Box{},
@@ -74,6 +74,11 @@ func (b Bndl) WithRootFS(absolutePath string) Bndl {
 // GetRootfsPath returns the path to the rootfs of this bundle. Nothing is modified
 func (b Bndl) RootFS() string {
 	return b.Spec.Root.Path
+}
+
+func (b Bndl) WithWindowsLayerFolders(layerFolders []string) Bndl {
+	b.CloneWindows().Spec.Windows.LayerFolders = layerFolders
+	return b
 }
 
 // WithResources returns a bundle with the resources replaced with the given Resources. The original bundle is not modified.

--- a/rundmc/goci/bundle_test.go
+++ b/rundmc/goci/bundle_test.go
@@ -238,6 +238,24 @@ var _ = Describe("Bundle", func() {
 		})
 	})
 
+	Describe("WithWindowsLayerFolders", func() {
+		var layerFolders []string
+
+		BeforeEach(func() {
+			layerFolders = []string{"layer-1", "layer-0"}
+			returnedBundle = initialBundle.WithWindowsLayerFolders(layerFolders)
+		})
+
+		It("returns a bundle with the windows layerFolders", func() {
+			Expect(returnedBundle.Spec.Windows.LayerFolders).To(Equal(layerFolders))
+		})
+
+		It("does not modify the original bundle", func() {
+			Expect(returnedBundle).NotTo(Equal(initialBundle))
+			Expect(initialBundle.Resources()).To(BeNil())
+		})
+	})
+
 	Describe("WithCPUShares", func() {
 		var shares uint64 = 10
 


### PR DESCRIPTION
- Read LayerFolders from image plugin
- Guardian writes windows.LayerFolders for bundle

[#149185707]

Signed-off-by: Amin Jamali <ajamali@pivotal.io>