### PR TITLE
Change default rootfs propagation to 'private'

### DIFF
--- a/gqt/bind_mount_test.go
+++ b/gqt/bind_mount_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"code.cloudfoundry.org/garden"
@@ -60,7 +61,12 @@ var _ = Describe("Bind mount", func() {
 	})
 
 	AfterEach(func() {
-		err := os.RemoveAll(srcPath)
+		cmd := exec.Command("umount", "-f", srcPath)
+		output, err := cmd.CombinedOutput()
+		fmt.Println(string(output))
+		Expect(err).NotTo(HaveOccurred())
+
+		err = os.RemoveAll(srcPath)
 		Expect(err).ToNot(HaveOccurred())
 
 		if container != nil {
@@ -101,6 +107,40 @@ var _ = Describe("Bind mount", func() {
 				writeProcess := writeFile(container, dstPath, "root")
 				Expect(writeProcess.Wait()).ToNot(Equal(0))
 			})
+
+			Describe("nested-mounts", func() {
+				JustBeforeEach(func() {
+					mountNested(srcPath)
+				})
+
+				AfterEach(func() {
+					unmountNested(srcPath)
+				})
+
+				It("allows all users to read from nested bind mounts", func() {
+					nestedPath := filepath.Join(dstPath, "nested-bind")
+					readProcess := readFile(container, nestedPath, "nested-file", "alice")
+					Expect(readProcess.Wait()).To(Equal(0))
+				})
+
+				It("allows non-root to write to nested bind mounts", func() {
+					nestedPath := filepath.Join(dstPath, "nested-bind")
+					writeProcess := writeFile(container, nestedPath, "alice")
+					Expect(writeProcess.Wait()).To(Equal(0))
+				})
+
+				It("allows root to read from nested bind mounts", func() {
+					nestedPath := filepath.Join(dstPath, "nested-bind")
+					readProcess := readFile(container, nestedPath, "nested-file", "alice")
+					Expect(readProcess.Wait()).To(Equal(0))
+				})
+
+				It("allows root to write to from nested bind mounts", func() {
+					nestedPath := filepath.Join(dstPath, "nested-bind")
+					writeProcess := writeFile(container, nestedPath, "root")
+					Expect(writeProcess.Wait()).To(Equal(0))
+				})
+			})
 		})
 
 		Context("and with privileged=false", func() {
@@ -113,7 +153,7 @@ var _ = Describe("Bind mount", func() {
 				Expect(readProcess.Wait()).To(Equal(0))
 			})
 
-			It("does not allow non-root users to write files", func() {
+			It("allows non-root users to write files", func() {
 				writeProcess := writeFile(container, dstPath, "alice")
 				Expect(writeProcess.Wait()).ToNot(Equal(0))
 			})
@@ -126,6 +166,40 @@ var _ = Describe("Bind mount", func() {
 			It("does not allow root to write files", func() {
 				writeProcess := writeFile(container, dstPath, "root")
 				Expect(writeProcess.Wait()).ToNot(Equal(0))
+			})
+
+			Describe("nested-mounts", func() {
+				JustBeforeEach(func() {
+					mountNested(srcPath)
+				})
+
+				AfterEach(func() {
+					unmountNested(srcPath)
+				})
+
+				It("allows all users to read from nested bind mounts", func() {
+					nestedPath := filepath.Join(dstPath, "nested-bind")
+					readProcess := readFile(container, nestedPath, "nested-file", "alice")
+					Expect(readProcess.Wait()).To(Equal(0))
+				})
+
+				It("allows non-root to write to nested bind mounts", func() {
+					nestedPath := filepath.Join(dstPath, "nested-bind")
+					writeProcess := writeFile(container, nestedPath, "alice")
+					Expect(writeProcess.Wait()).To(Equal(0))
+				})
+
+				It("allows root to read from nested bind mounts", func() {
+					nestedPath := filepath.Join(dstPath, "nested-bind")
+					readProcess := readFile(container, nestedPath, "nested-file", "alice")
+					Expect(readProcess.Wait()).To(Equal(0))
+				})
+
+				It("allows root to write to from nested bind mounts", func() {
+					nestedPath := filepath.Join(dstPath, "nested-bind")
+					writeProcess := writeFile(container, nestedPath, "root")
+					Expect(writeProcess.Wait()).To(Equal(0))
+				})
 			})
 		})
 	})
@@ -160,6 +234,40 @@ var _ = Describe("Bind mount", func() {
 				writeProcess := writeFile(container, dstPath, "root")
 				Expect(writeProcess.Wait()).To(Equal(0))
 			})
+
+			Describe("nested-mounts", func() {
+				JustBeforeEach(func() {
+					mountNested(srcPath)
+				})
+
+				AfterEach(func() {
+					unmountNested(srcPath)
+				})
+
+				It("allows all users to read from nested bind mounts", func() {
+					nestedPath := filepath.Join(dstPath, "nested-bind")
+					readProcess := readFile(container, nestedPath, "nested-file", "alice")
+					Expect(readProcess.Wait()).To(Equal(0))
+				})
+
+				It("allows non-root to write to nested bind mounts", func() {
+					nestedPath := filepath.Join(dstPath, "nested-bind")
+					writeProcess := writeFile(container, nestedPath, "alice")
+					Expect(writeProcess.Wait()).To(Equal(0))
+				})
+
+				It("allows root to read from nested bind mounts", func() {
+					nestedPath := filepath.Join(dstPath, "nested-bind")
+					readProcess := readFile(container, nestedPath, "nested-file", "alice")
+					Expect(readProcess.Wait()).To(Equal(0))
+				})
+
+				It("allows root to write to from nested bind mounts", func() {
+					nestedPath := filepath.Join(dstPath, "nested-bind")
+					writeProcess := writeFile(container, nestedPath, "root")
+					Expect(writeProcess.Wait()).To(Equal(0))
+				})
+			})
 		})
 
 		Context("and with privileged=false", func() {
@@ -189,6 +297,40 @@ var _ = Describe("Bind mount", func() {
 				writeProcess := writeFile(container, dstPath, "root")
 				Expect(writeProcess.Wait()).NotTo(Equal(0))
 			})
+
+			Describe("nested-mounts", func() {
+				JustBeforeEach(func() {
+					mountNested(srcPath)
+				})
+
+				AfterEach(func() {
+					unmountNested(srcPath)
+				})
+
+				It("allows all users to read from nested bind mounts", func() {
+					nestedPath := filepath.Join(dstPath, "nested-bind")
+					readProcess := readFile(container, nestedPath, "nested-file", "alice")
+					Expect(readProcess.Wait()).To(Equal(0))
+				})
+
+				It("allows non-root to write to nested bind mounts", func() {
+					nestedPath := filepath.Join(dstPath, "nested-bind")
+					writeProcess := writeFile(container, nestedPath, "alice")
+					Expect(writeProcess.Wait()).To(Equal(0))
+				})
+
+				It("allows root to read from nested bind mounts", func() {
+					nestedPath := filepath.Join(dstPath, "nested-bind")
+					readProcess := readFile(container, nestedPath, "nested-file", "alice")
+					Expect(readProcess.Wait()).To(Equal(0))
+				})
+
+				It("allows root to write to from nested bind mounts", func() {
+					nestedPath := filepath.Join(dstPath, "nested-bind")
+					writeProcess := writeFile(container, nestedPath, "root")
+					Expect(writeProcess.Wait()).To(Equal(0))
+				})
+			})
 		})
 	})
 })
@@ -201,12 +343,39 @@ func createTestHostDirAndTestFile() (string, string) {
 	err = os.Chmod(tstHostDir, 0755)
 	Expect(err).ToNot(HaveOccurred())
 
+	var cmd *exec.Cmd
+	cmd = exec.Command("mount", "--bind", tstHostDir, tstHostDir)
+	Expect(cmd.Run()).To(Succeed())
+
+	cmd = exec.Command("mount", "--make-shared", tstHostDir)
+	Expect(cmd.Run()).To(Succeed())
+
 	fileName := fmt.Sprintf("bind-mount-%d-test-file", GinkgoParallelNode())
 	file, err := os.OpenFile(filepath.Join(tstHostDir, fileName), os.O_CREATE|os.O_RDWR, 0777)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(file.Close()).ToNot(HaveOccurred())
 
 	return tstHostDir, fileName
+}
+
+func mountNested(srcPath string) {
+	nestedBindPath := filepath.Join(srcPath, "nested-bind")
+	Expect(os.MkdirAll(nestedBindPath, os.FileMode(0755))).To(Succeed())
+
+	cmd := exec.Command("mount", "-t", "tmpfs", "tmpfs", nestedBindPath)
+	Expect(cmd.Run()).To(Succeed())
+
+	file, err := os.OpenFile(filepath.Join(nestedBindPath, "nested-file"), os.O_CREATE|os.O_RDWR, 0777)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(file.Close()).ToNot(HaveOccurred())
+}
+
+func unmountNested(srcPath string) {
+	nestedPath := filepath.Join(srcPath, "nested-bind")
+	cmd := exec.Command("umount", "-f", nestedPath)
+	output, err := cmd.CombinedOutput()
+	fmt.Println(string(output))
+	Expect(err).NotTo(HaveOccurred())
 }
 
 func readFile(container garden.Container, dstPath, fileName, user string) garden.Process {

--- a/guardiancmd/command.go
+++ b/guardiancmd/command.go
@@ -638,7 +638,8 @@ func (cmd *ServerCommand) wireContainerizer(log lager.Logger,
 		WithResources(&specs.LinuxResources{Devices: append([]specs.LinuxDeviceCgroup{denyAll}, allowedDevices...)}).
 		WithRootFS(cmd.Containers.DefaultRootFS).
 		WithDevices(fuseDevice).
-		WithProcess(baseProcess)
+		WithProcess(baseProcess).
+		WithRootFSPropagation("private")
 	unprivilegedBundle := baseBundle.
 		WithNamespace(goci.UserNamespace).
 		WithUIDMappings(uidMappings...).

--- a/rundmc/goci/bundle.go
+++ b/rundmc/goci/bundle.go
@@ -62,6 +62,15 @@ func (b Bndl) WithRootFS(absolutePath string) Bndl {
 	return b
 }
 
+func (b Bndl) RootFSPropagation() string {
+	return b.Spec.Linux.RootfsPropagation
+}
+
+func (b Bndl) WithRootFSPropagation(rootfsPropagation string) Bndl {
+	b.Spec.Linux.RootfsPropagation = rootfsPropagation
+	return b
+}
+
 // GetRootfsPath returns the path to the rootfs of this bundle. Nothing is modified
 func (b Bndl) RootFS() string {
 	return b.Spec.Root.Path

--- a/rundmc/goci/bundle_test.go
+++ b/rundmc/goci/bundle_test.go
@@ -26,6 +26,13 @@ var _ = Describe("Bundle", func() {
 		})
 	})
 
+	Describe("WithRootFSPropagation", func() {
+		It("sets the RootFSPropagation in the bundle", func() {
+			returnedBundle := initialBundle.WithRootFSPropagation("rshared")
+			Expect(returnedBundle.RootFSPropagation()).To(Equal("rshared"))
+		})
+	})
+
 	Describe("WithCapabilities", func() {
 		It("adds capabilities to the bundle", func() {
 			returnedBundle := initialBundle.WithCapabilities("growtulips", "waterspuds")


### PR DESCRIPTION
This allows for nested mounts within a bind mount, which is needed for
the bosh-warden-cpi to properly attach "persistent" disks.

This PR replaces #92 as it solves the problem more directly without new configuration. The current default is `rprivate` which breaks nested mounts within bind mounts, garden-linux used to do `private` so this puts that behaviour back in place.

Closes #92 