### PR TITLE
Allow extra args to be passed to runtime plugin create

### DIFF
--- a/gqt/cmd/fake_runtime_plugin/main.go
+++ b/gqt/cmd/fake_runtime_plugin/main.go
@@ -31,6 +31,9 @@ func main() {
 		cli.StringFlag{
 			Name: "log-format",
 		},
+		cli.StringFlag{
+			Name: "image-store",
+		},
 	}
 
 	fakeRuntimePlugin.Commands = []cli.Command{

--- a/gqt/runner/runner.go
+++ b/gqt/runner/runner.go
@@ -56,6 +56,7 @@ type GdnRunnerConfig struct {
 	DefaultBlkioWeight             *uint64  `flag:"default-container-blockio-weight"`
 	NetworkPluginExtraArgs         []string `flag:"network-plugin-extra-arg"`
 	ImagePluginExtraArgs           []string `flag:"image-plugin-extra-arg"`
+	RuntimePluginExtraArgs         []string `flag:"runtime-plugin-extra-arg"`
 	PrivilegedImagePluginExtraArgs []string `flag:"privileged-image-plugin-extra-arg"`
 	MaxContainers                  *uint64  `flag:"max-containers"`
 	DebugIP                        string   `flag:"debug-bind-ip"`

--- a/gqt/runtime_plugin_test.go
+++ b/gqt/runtime_plugin_test.go
@@ -36,6 +36,9 @@ var _ = Describe("Runtime Plugin", func() {
 			config.RuntimePluginBin = binaries.RuntimePlugin
 			config.NetworkPluginBin = binaries.NetworkPlugin
 			config.ImagePluginBin = binaries.NoopPlugin
+			config.RuntimePluginExtraArgs = []string{
+				`"--image-store"`, `some-image-store`,
+			}
 		})
 
 		Describe("creating a container", func() {
@@ -58,6 +61,7 @@ var _ = Describe("Runtime Plugin", func() {
 					"--debug",
 					"--log", HaveSuffix(filepath.Join("containers", handle, "create.log")),
 					"--log-format", "json",
+					"--image-store", "some-image-store",
 					"create",
 					"--no-new-keyring",
 					"--bundle", HaveSuffix(filepath.Join("containers", handle)),

--- a/rundmc/runrunc/create.go
+++ b/rundmc/runrunc/create.go
@@ -17,13 +17,15 @@ import (
 type Creator struct {
 	runcPath      string
 	runcSubcmd    string
+	runcExtraArgs []string
 	commandRunner commandrunner.CommandRunner
 }
 
-func NewCreator(runcPath, runcSubcmd string, commandRunner commandrunner.CommandRunner) *Creator {
+func NewCreator(runcPath, runcSubcmd string, runcExtraArgs []string, commandRunner commandrunner.CommandRunner) *Creator {
 	return &Creator{
 		runcPath,
 		runcSubcmd,
+		runcExtraArgs,
 		commandRunner,
 	}
 }
@@ -54,7 +56,7 @@ func (c *Creator) Create(log lager.Logger, bundlePath, id string, pio garden.Pro
 		"--pid-file", pidFilePath,
 		id,
 	}
-	cmd := exec.Command(c.runcPath, append(globalArgs, subcmdArgs...)...)
+	cmd := exec.Command(c.runcPath, append(globalArgs, append(c.runcExtraArgs, subcmdArgs...)...)...)
 
 	if pio.Stdin != nil {
 		pipeR, pipeW, err := os.Pipe()

--- a/rundmc/runrunc/create_test.go
+++ b/rundmc/runrunc/create_test.go
@@ -24,6 +24,7 @@ var _ = Describe("Create", func() {
 		commandRunner  *fake_command_runner.FakeCommandRunner
 		bundlePath     string
 		runcSubcmd     = "do-a-thing"
+		runcExtraArgs  = []string{"--some-arg", "some-value"}
 		logFilePath    string
 		pidFilePath    string
 		logger         *lagertest.TestLogger
@@ -48,7 +49,7 @@ var _ = Describe("Create", func() {
 	})
 
 	JustBeforeEach(func() {
-		runner = runrunc.NewCreator("funC", runcSubcmd, commandRunner)
+		runner = runrunc.NewCreator("funC", runcSubcmd, runcExtraArgs, commandRunner)
 
 		commandRunner.WhenRunning(fake_command_runner.CommandSpec{
 			Path: "funC",
@@ -82,6 +83,7 @@ var _ = Describe("Create", func() {
 			"--debug",
 			"--log", logFilePath,
 			"--log-format", "json",
+			runcExtraArgs[0], runcExtraArgs[1],
 			runcSubcmd,
 			"--no-new-keyring",
 			"--bundle", bundlePath,

--- a/rundmc/runrunc/runrunc.go
+++ b/rundmc/runrunc/runrunc.go
@@ -33,9 +33,9 @@ type RuncBinary interface {
 	DeleteCommand(id, logFile string) *exec.Cmd
 }
 
-func New(runner commandrunner.CommandRunner, runcCmdRunner RuncCmdRunner, runc RuncBinary, dadooPath, runcPath string, execPreparer ExecPreparer, execRunner ExecRunner) *RunRunc {
+func New(runner commandrunner.CommandRunner, runcCmdRunner RuncCmdRunner, runc RuncBinary, dadooPath, runcPath string, runcExtraArgs []string, execPreparer ExecPreparer, execRunner ExecRunner) *RunRunc {
 	return &RunRunc{
-		Creator: NewCreator(runcPath, "create", runner),
+		Creator: NewCreator(runcPath, "create", runcExtraArgs, runner),
 		Execer:  NewExecer(execPreparer, execRunner),
 
 		OomWatcher: NewOomWatcher(runner, runc),


### PR DESCRIPTION
This is used by `winc` in place of the removed `--runc-root` flag.

We did not pass the extra args to any other subcommands of the runtime-plugin (i.e. `exec`) because it wasn't necessary for our use case.