### PR TITLE
Forward logs from windows execrunner to guardian

### DIFF
--- a/gqt/runtime_plugin_test.go
+++ b/gqt/runtime_plugin_test.go
@@ -166,7 +166,7 @@ var _ = Describe("Runtime Plugin", func() {
 					pluginArgs := []interface{}{
 						binaries.RuntimePlugin,
 						"--debug",
-						"--log", MatchRegexp(".*"),
+						"--log", HaveSuffix("exec.log"),
 						"--log-format", "json",
 						"exec",
 						"-p", MatchRegexp(".*"),


### PR DESCRIPTION
Retrieve `winc exec` logs in `garden-windows` job when running with `log_level: debug`

Signed-off-by: Mark DeLillo <mdelillo@pivotal.io>