### PR TITLE
Add support for peas on Windows

### DIFF
--- a/guardiancmd/command_windows.go
+++ b/guardiancmd/command_windows.go
@@ -61,6 +61,7 @@ func (f *WindowsFactory) WireExecRunner(runMode string) runrunc.ExecRunner {
 	return &execrunner.DirectExecRunner{
 		RuntimePath:   f.config.Runtime.Plugin,
 		CommandRunner: f.commandRunner,
+		RunMode:       runMode,
 	}
 }
 

--- a/rundmc/goci/bundle.go
+++ b/rundmc/goci/bundle.go
@@ -14,6 +14,7 @@ func Bundle() Bndl {
 			Version: "1.0.0",
 			Linux:   &specs.Linux{},
 			Windows: &specs.Windows{
+				Network:      &specs.WindowsNetwork{},
 				LayerFolders: []string{},
 			},
 			Process: &specs.Process{

--- a/rundmc/peas/pea_creator.go
+++ b/rundmc/peas/pea_creator.go
@@ -94,6 +94,14 @@ func (p *PeaCreator) CreatePea(log lager.Logger, spec garden.ProcessSpec, procIO
 		return errs("creating-volume", err)
 	}
 
+	if runtimeSpec.Windows == nil {
+		runtimeSpec.Windows = &specs.Windows{}
+	}
+
+	runtimeSpec.Windows.Network = &specs.WindowsNetwork{
+		NetworkSharedContainerName: sandboxHandle,
+	}
+
 	cgroupPath := sandboxHandle
 	if spec.OverrideContainerLimits != nil {
 		cgroupPath = processID


### PR DESCRIPTION
This PR allows the DirectExecRunner (used on Windows) to be called with either `exec` or `run`.

It satisfies the peas API but doesn't have full parity with linux. For example, memory limits are not inherited from the parent container (i.e. [these tests](https://github.com/cloudfoundry/garden-integration-tests/blob/f14395737215a599f9d647c51e2db1cd137533e2/peas_test.go#L185-L216) won't pass on Windows).

@mdelillo @aminjam 