### PR TITLE
Write exec log files to a temp dir on Windows

### DIFF
--- a/gqt/runtime_plugin_test.go
+++ b/gqt/runtime_plugin_test.go
@@ -131,7 +131,7 @@ var _ = Describe("Runtime Plugin", func() {
 						Expect(readPluginArgs(argsFilepath)).To(ConsistOf(
 							binaries.RuntimePlugin,
 							"--debug",
-							"--log", HaveSuffix(filepath.Join("containers", handle, "processes", procId, "run.log")),
+							"--log", HaveSuffix(filepath.Join(procId, "run.log")),
 							"--log-format", "json",
 							"run",
 							"--pid-file", HaveSuffix(filepath.Join("containers", handle, "processes", procId, "pidfile")),

--- a/rundmc/execrunner/windows_execrunner.go
+++ b/rundmc/execrunner/windows_execrunner.go
@@ -34,7 +34,12 @@ func (e *DirectExecRunner) Run(
 	log.Info("start")
 	defer log.Info("done")
 
-	logPath := filepath.Join(processPath, fmt.Sprintf("%s.log", e.RunMode))
+	logDir := filepath.Join(os.TempDir(), processID)
+	if err := os.MkdirAll(logDir, 0755); err != nil {
+		return nil, errors.Wrap(err, "creating log temp dir")
+	}
+
+	logPath := filepath.Join(logDir, fmt.Sprintf("%s.log", e.RunMode))
 	cmd := exec.Command(e.RuntimePath, "--debug", "--log", logPath, "--log-format", "json", e.RunMode, "--pid-file", filepath.Join(processPath, "pidfile"))
 
 	if e.RunMode == "exec" {
@@ -130,7 +135,7 @@ func (p *process) Signal(signal garden.Signal) error {
 }
 
 func forwardLogs(log lager.Logger, logPath string) {
-	defer os.Remove(logPath)
+	defer os.RemoveAll(filepath.Dir(logPath))
 
 	buff, readErr := ioutil.ReadFile(logPath)
 	if readErr != nil {


### PR DESCRIPTION
Before this change, a pea process would write its log file to a
subdirectory of the main container's directory in the depot. This causes a
problem when the main container is deleted. The deletion of the
container's depot directory will fail because the exec process for the pea will
have an open handle to its log file. This causes guardian to incorrectly report the
number of containers, as it counts the un-deleted directories in the
deport (even though the actual containers are gone)

Writing the log file to a temp dir allows deletion of the container's
depot directory to succeed

Signed-off-by: Andrew Keesler <akeesler@pivotal.io>