### PR TITLE
When creating cgroups, look up the mount source and skip it

### DIFF
--- a/cmd/dadoo/dadoo_linux_test.go
+++ b/cmd/dadoo/dadoo_linux_test.go
@@ -893,7 +893,7 @@ func setupCgroups(cgroupsRoot string) error {
 	logger := lagertest.NewTestLogger("test")
 	runner := linux_command_runner.New()
 
-	starter := cgroups.NewStarter(logger, mustOpen("/proc/cgroups"), mustOpen("/proc/self/cgroup"), cgroupsRoot, "garden", []specs.LinuxDeviceCgroup{}, runner, &cgroups.OSChowner{})
+	starter := cgroups.NewStarter(logger, mustOpen("/proc/cgroups"), mustOpen("/proc/self/cgroup"), mustOpen("/proc/self/mountinfo"), cgroupsRoot, "garden", []specs.LinuxDeviceCgroup{}, runner, &cgroups.OSChowner{})
 
 	return starter.Start()
 }

--- a/guardiancmd/command_linux.go
+++ b/guardiancmd/command_linux.go
@@ -119,7 +119,8 @@ func createCgroupsStarter(logger lager.Logger, tag string, chowner cgroups.Chown
 	}
 
 	return cgroups.NewStarter(logger, mustOpen("/proc/cgroups"), mustOpen("/proc/self/cgroup"),
-		cgroupsMountpoint, gardenCgroup, allowedDevices, linux_command_runner.New(), chowner)
+		mustOpen("/proc/self/mountinfo"), cgroupsMountpoint, gardenCgroup, allowedDevices,
+		linux_command_runner.New(), chowner)
 }
 
 func (f *LinuxFactory) WireResolvConfigurer() kawasaki.DnsResolvConfigurer {


### PR DESCRIPTION
This is, basically, a workaround for https://github.com/moby/moby/issues/34584

When creating cgroup directories, check that our cgroup mountpoint isn't itself a child cgroup; if it is, adjust the paths accordingly so that the paths (relative to the top cgroup) is correct.  Otherwise we end up with cgroups that have duplicate sections in the path.