### PR TITLE
Log external networker plugin Stderr when stderr is not empty

### DIFF
--- a/netplugin/external_networker.go
+++ b/netplugin/external_networker.go
@@ -265,6 +265,11 @@ func (p *externalBinaryNetworker) exec(log lager.Logger, action, handle string,
 		}
 	}
 
+	if stderr.Len() > 0 {
+		log.Info("external-networker-result", lager.Data{"stderr": stderr.String()})
+	}
+
 	log.Debug("external-networker-result", logData)
+
 	return nil
 }


### PR DESCRIPTION
The container networking external networking plugin is going to start outputting warnings to stderr even when exit code is zero. We would want this to be seen even when the log level is not debug.

/cc @ameowlia