### PR TITLE
Fix int overflow in 32bit builds

### DIFF
--- a/guardiancmd/command.go
+++ b/guardiancmd/command.go
@@ -356,7 +356,7 @@ func (cmd *ServerCommand) Execute([]string) error {
 }
 
 func newInitStoreCommand(pluginPath string, pluginGlobalArgs []string) *exec.Cmd {
-	return exec.Command(pluginPath, append(pluginGlobalArgs, "init-store", "--store-size-bytes", strconv.Itoa(10*1024*1024*1024))...)
+	return exec.Command(pluginPath, append(pluginGlobalArgs, "init-store", "--store-size-bytes", strconv.FormatInt(10*1024*1024*1024, 10))...)
 }
 
 func runCommand(cmd *exec.Cmd) {


### PR DESCRIPTION
When building guardian on 32bit platforms go will complain for overflows because strconv.Itoa's argument is of type int.

Switch to FormatInt that accepts a int64.