### PR TITLE
gdn: don't force --allow-host-access

### DIFF
--- a/guardiancmd/command.go
+++ b/guardiancmd/command.go
@@ -336,8 +336,6 @@ func (cmd *ServerCommand) Execute([]string) error {
 			"--log-level", cmd.Logger.LogLevel,
 		}
 
-		cmd.Network.AllowHostAccess = true
-
 		maxId := mustGetMaxValidUID()
 
 		initStoreCmd := newInitStoreCommand(cmd.Image.Plugin.Path(), cmd.Image.PluginExtraArgs)


### PR DESCRIPTION
not sure why this was being set, but it doesn't seem like a 'sane default' for folks using `gdn` for projects concerned with security