### PR TITLE
Do not report container age if runtime plugin doesnt report Created time

### DIFF
--- a/rundmc/runrunc/stats.go
+++ b/rundmc/runrunc/stats.go
@@ -73,7 +73,9 @@ func (r *Statser) Stats(log lager.Logger, id string) (gardener.StatsContainerMet
 			Current: containerStats.Data.PidStats.Current,
 			Max:     containerStats.Data.PidStats.Max,
 		},
-		Age: time.Since(containerState.Created),
+	}
+	if !containerState.Created.IsZero() {
+		stats.Age = time.Since(containerState.Created)
 	}
 
 	stats.Memory.TotalUsageTowardLimit = stats.Memory.TotalRss + (stats.Memory.TotalCache - stats.Memory.TotalInactiveFile)

--- a/rundmc/runrunc/stats_test.go
+++ b/rundmc/runrunc/stats_test.go
@@ -205,6 +205,30 @@ var _ = Describe("Stats", func() {
 		})
 	})
 
+	Context("when runC state does not report a created time", func() {
+		BeforeEach(func() {
+			commandRunner.WhenRunning(fake_command_runner.CommandSpec{
+				Path: "funC-stats",
+			}, func(cmd *exec.Cmd) error {
+				cmd.Stdout.Write([]byte(`{}`))
+				return nil
+			})
+			commandRunner.WhenRunning(fake_command_runner.CommandSpec{
+				Path: "funC-state",
+			}, func(cmd *exec.Cmd) error {
+				cmd.Stdout.Write([]byte(`{}`))
+				return nil
+			})
+		})
+
+		It("does not report the container's age", func() {
+			stats, err := statser.Stats(logger, "some-handle")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(stats.Age).To(Equal(time.Duration(0)))
+		})
+	})
+
 	Context("when runC stats reports invalid JSON", func() {
 		BeforeEach(func() {
 			commandRunner.WhenRunning(fake_command_runner.CommandSpec{


### PR DESCRIPTION
The `Created` time field `runc` outputs as part of it's container `state` is not part of the [runtime spec](https://github.com/opencontainers/runtime-spec/blob/a1b50f621a48ad13f8f696a162f684a241307db0/specs-go/state.go#L4-L17). If `guardian` is run with a runtime plugin that does not output this (e.g. `winc`), then the `Age` field calculated by `guardian` is very incorrect and also does not change as the container ages, as it is the max `int64` value possible.

See https://github.com/cloudfoundry/guardian/issues/126

(I haven't run all the tests, just the units in `rundmc/runrunc`)