### PR TITLE
Do not log empty output from image plugins

### DIFF
--- a/imageplugin/relogger.go
+++ b/imageplugin/relogger.go
@@ -37,6 +37,9 @@ func (r Relogger) Write(data []byte) (n int, err error) {
 }
 
 func (r Relogger) relogEntry(entry chug.Entry) {
+	if len(entry.Raw) == 0 {
+		return
+	}
 	if !entry.IsLager {
 		r.destination.Error("error", nil, map[string]interface{}{"output": string(entry.Raw)})
 		return

--- a/imageplugin/relogger_test.go
+++ b/imageplugin/relogger_test.go
@@ -78,6 +78,15 @@ var _ = Describe("ImagePlugin", func() {
 		Expect(data[0]["original_timestamp"]).To(BeTemporally("~", time.Unix(1540895553, 922393799), 100*time.Nanosecond))
 	})
 
+	It("skips empty logs", func() {
+		_, err := relogger.Write([]byte{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(fakeLogger.ErrorCallCount()).To(Equal(0))
+		Expect(fakeLogger.InfoCallCount()).To(Equal(0))
+		Expect(fakeLogger.DebugCallCount()).To(Equal(0))
+	})
+
 	Context("when the entry is not a lager log entry", func() {
 		It("wraps it with a lager error log entry", func() {
 			_, err := relogger.Write([]byte(`some random log line`))


### PR DESCRIPTION
We have seen in our environments that any image plugin command that
attaches the ReLogger will still print out a log line if there is empty
output. This is especially misleading in logs b/c it does not parse the
empty output as a lager log line and then prints out an error level log
(with no error, but the log message has '.error' appended). This change
should also reduce the total log volume of guardian (e.g. in a log file
from a Windows cell with 82982 total lines, there were 42459 that
matched 'image-plugin.*error' and had an empty output string in the log
data)


@cloudfoundry/cf-diego 