### PR TITLE
Extract files as provided user

### DIFF
--- a/rundmc/nstar/nstar.c
+++ b/rundmc/nstar/nstar.c
@@ -229,9 +229,9 @@ int main(int argc, char **argv) {
   }
 
   if(compress != NULL) {
-    execveat(tarfd, "", (const char*[5]){"tar", "cf", "-", compress, NULL}, NULL, AT_EMPTY_PATH);
+    execveat(tarfd, "", (char*[7]){"tar", "--no-same-permissions", "--no-same-owner", "-cf", "-", compress, NULL}, NULL, AT_EMPTY_PATH);
   } else {
-    execveat(tarfd, "", (const char*[4]){"tar", "xf", "-", NULL}, NULL, AT_EMPTY_PATH);
+    execveat(tarfd, "", (char*[6]){"tar", "--no-same-permissions", "--no-same-owner", "-xf", "-", NULL}, NULL, AT_EMPTY_PATH);
   }
   /* execveat will not return if successful, so if we get here, we know there's been an error */
   perror("execveat");


### PR DESCRIPTION
--no-same-permissions and --no-same-owner are default for non root
users. When running nstar as root tar fails to set permissions on an
extracted file because the user in rootfs can not see files created by
the original user. Set these flags explicitly so that they get applied
for "root" user as well.