### PR TITLE
Containers that are partially created can be fetched for cleanup

### DIFF
--- a/gardener/gardener.go
+++ b/gardener/gardener.go
@@ -454,7 +454,11 @@ func (g *Gardener) Containers(props garden.Properties) ([]garden.Container, erro
 	if props == nil {
 		props = garden.Properties{}
 	}
-	props["garden.state"] = "created"
+	if _, ok := props["garden.state"]; !ok {
+		props["garden.state"] = "created"
+	} else if props["garden.state"] == "all" {
+		delete(props, "garden.state")
+	}
 
 	var containers []garden.Container
 	for _, handle := range handles {

--- a/gardener/gardener.go
+++ b/gardener/gardener.go
@@ -263,6 +263,17 @@ func (g *Gardener) Create(containerSpec garden.ContainerSpec) (ctr garden.Contai
 		log.Error("graph-cleanup-failed", err)
 	}
 
+	container, err := g.Lookup(containerSpec.Handle)
+	if err != nil {
+		return nil, err
+	}
+
+	for name, value := range containerSpec.Properties {
+		if err := container.SetProperty(name, value); err != nil {
+			return nil, err
+		}
+	}
+
 	runtimeSpec, err := g.Volumizer.Create(log, containerSpec)
 	if err != nil {
 		return nil, err
@@ -302,19 +313,8 @@ func (g *Gardener) Create(containerSpec garden.ContainerSpec) (ctr garden.Contai
 		return nil, err
 	}
 
-	container, err := g.Lookup(containerSpec.Handle)
-	if err != nil {
-		return nil, err
-	}
-
 	if containerSpec.GraceTime != 0 {
 		if err := container.SetGraceTime(containerSpec.GraceTime); err != nil {
-			return nil, err
-		}
-	}
-
-	for name, value := range containerSpec.Properties {
-		if err := container.SetProperty(name, value); err != nil {
 			return nil, err
 		}
 	}

--- a/gardener/gardener_test.go
+++ b/gardener/gardener_test.go
@@ -195,6 +195,15 @@ var _ = Describe("Gardener", func() {
 				Expect(err).To(MatchError("booom!"))
 			})
 
+			It("retains container properties", func() {
+				gdnr.Create(garden.ContainerSpec{Handle: "bob", Properties: garden.Properties{"owner": "some-owner"}})
+				Expect(propertyManager.SetCallCount()).To(Equal(1))
+				handle, name, value := propertyManager.SetArgsForCall(0)
+				Expect(handle).To(Equal("bob"))
+				Expect(name).To(Equal("owner"))
+				Expect(value).To(Equal("some-owner"))
+			})
+
 			It("should not call the containerizer", func() {
 				gdnr.Create(garden.ContainerSpec{Handle: "bob"})
 				Expect(containerizer.CreateCallCount()).To(Equal(0))
@@ -239,11 +248,22 @@ var _ = Describe("Gardener", func() {
 		})
 
 		Context("when setting up bind mounts fails", func() {
-			It("returns the error", func() {
+			BeforeEach(func() {
 				networker.SetupBindMountsReturns(nil, errors.New("failed"))
+			})
 
+			It("returns the error", func() {
 				_, err := gdnr.Create(garden.ContainerSpec{Handle: "some-ctr"})
 				Expect(err).To(MatchError("failed"))
+			})
+
+			It("sets the container properties", func() {
+				gdnr.Create(garden.ContainerSpec{Handle: "bob", Properties: garden.Properties{"owner": "some-owner"}})
+				Expect(propertyManager.SetCallCount()).To(Equal(1))
+				handle, name, value := propertyManager.SetArgsForCall(0)
+				Expect(handle).To(Equal("bob"))
+				Expect(name).To(Equal("owner"))
+				Expect(value).To(Equal("some-owner"))
 			})
 		})
 
@@ -274,6 +294,15 @@ var _ = Describe("Gardener", func() {
 					Handle: "poor-banana",
 				})
 				Expect(err).To(HaveOccurred())
+			})
+
+			It("sets container properties", func() {
+				gdnr.Create(garden.ContainerSpec{Handle: "bob", Properties: garden.Properties{"owner": "some-owner"}})
+				Expect(propertyManager.SetCallCount()).To(Equal(1))
+				handle, name, value := propertyManager.SetArgsForCall(0)
+				Expect(handle).To(Equal("bob"))
+				Expect(name).To(Equal("owner"))
+				Expect(value).To(Equal("some-owner"))
 			})
 
 			ItDestroysEverything()
@@ -318,6 +347,16 @@ var _ = Describe("Gardener", func() {
 					_, handle := containerizer.DestroyArgsForCall(0)
 					Expect(handle).To(Equal("poor-banana"))
 				})
+
+				It("sets container properties", func() {
+					_, err := gdnr.Create(garden.ContainerSpec{Handle: "poor-banana", Properties: garden.Properties{"owner": "some-owner"}})
+					Expect(err).To(HaveOccurred())
+					Expect(propertyManager.SetCallCount()).To(Equal(1))
+					handle, name, value := propertyManager.SetArgsForCall(0)
+					Expect(handle).To(Equal("poor-banana"))
+					Expect(name).To(Equal("owner"))
+					Expect(value).To(Equal("some-owner"))
+				})
 			})
 
 			Context("when network destroy operation fails", func() {
@@ -335,6 +374,16 @@ var _ = Describe("Gardener", func() {
 					_, err := gdnr.Create(garden.ContainerSpec{Handle: "poor-banana"})
 					Expect(err).To(HaveOccurred())
 					Expect(containerizer.RemoveBundleCallCount()).To(BeZero())
+				})
+
+				It("sets container properties", func() {
+					_, err := gdnr.Create(garden.ContainerSpec{Handle: "poor-banana", Properties: garden.Properties{"owner": "some-owner"}})
+					Expect(err).To(HaveOccurred())
+					Expect(propertyManager.SetCallCount()).To(Equal(1))
+					handle, name, value := propertyManager.SetArgsForCall(0)
+					Expect(handle).To(Equal("poor-banana"))
+					Expect(name).To(Equal("owner"))
+					Expect(value).To(Equal("some-owner"))
 				})
 			})
 		})
@@ -405,6 +454,15 @@ var _ = Describe("Gardener", func() {
 
 				_, err := gdnr.Create(garden.ContainerSpec{Handle: "bob"})
 				Expect(err).To(MatchError("network-failed"))
+			})
+
+			It("sets container properties", func() {
+				gdnr.Create(garden.ContainerSpec{Handle: "bob", Properties: garden.Properties{"owner": "some-owner"}})
+				Expect(propertyManager.SetCallCount()).To(Equal(2)) // TODO chnage to 1 once we stop failure for non-healtcheck
+				handle, name, value := propertyManager.SetArgsForCall(0)
+				Expect(handle).To(Equal("bob"))
+				Expect(name).To(Equal("owner"))
+				Expect(value).To(Equal("some-owner"))
 			})
 		})
 

--- a/gardener/gardener_test.go
+++ b/gardener/gardener_test.go
@@ -879,6 +879,17 @@ var _ = Describe("Gardener", func() {
 
 			itOnlyMatchesFullyCreatedContainers(props)
 		})
+
+		Context("when garden state is set to all", func() {
+			It("returns all containers including non-created containers", func() {
+				props := garden.Properties{"garden.state": "all"}
+				_, err := gdnr.Containers(props)
+				Expect(err).NotTo(HaveOccurred())
+
+				_, props = propertyManager.MatchesAllArgsForCall(0)
+				Expect(props).ToNot(HaveKey("garden.state"))
+			})
+		})
 	})
 
 	Context("when no containers exist", func() {


### PR DESCRIPTION
In case if fail to create container (e.g. external networker is down) and we fail to immediately destroy it in the defer clause, we want to be able to find that container later and try to destroy it. So if later external networker comes up we can clean up containers and not leak them. 

To achieve that, we modified the Containers() call to be able to take in the `garden.state` property. It used to be always set to `created` which only returned successfully created containers. When Rep tried to get containers for clean up it was not getting containers that were partially created because they didn't have the `created` state. So now we can pass in the value `all` which will indicate to garden that we want containers in all states. When `all` is passed in we remove `garden.state` from the filter. This is done for backwards compatibility. By default `Containers()` call will return created containers.

We also saving container properties before we create container and its dependencies (volumes, network, bind mounts). So that in case of failure we can later get them by properties and retry clean up. When Rep creates containers it sets the owner property as `executor` and later when it cleans up it only pulls containers with that property. This is done in case when multiple services use garden to create containers, each of them might have different owner.

@reneighbor 