### PR TITLE
Fix process-leaks on cleanup.

### DIFF
--- a/guardiancmd/command_windows.go
+++ b/guardiancmd/command_windows.go
@@ -74,7 +74,7 @@ func (f *WindowsFactory) WireVolumizer(logger lager.Logger) gardener.Volumizer {
 }
 
 func (f *WindowsFactory) WireExecRunner(runcRoot string, _, _ uint32, bundleSaver depot.BundleSaver, bundleLookupper depot.BundleLookupper, processDepot execrunner.ProcessDepot) runrunc.ExecRunner {
-	return execrunner.NewWindowsExecRunner(f.config.Runtime.Plugin, f.commandRunner, bundleSaver, bundleLookupper, processDepot)
+	return execrunner.NewWindowsExecRunner(f.config.Runtime.Plugin, f.commandRunner, bundleSaver, bundleLookupper, processDepot, f.config.Containers.CleanupProcessDirsOnWait)
 }
 
 func (f *WindowsFactory) CommandRunner() commandrunner.CommandRunner {

--- a/rundmc/execrunner/dadoo/execrunner.go
+++ b/rundmc/execrunner/dadoo/execrunner.go
@@ -304,14 +304,19 @@ func (d *ExecRunner) getProcess(log lager.Logger, id, processPath, pidFilePath s
 		delete(d.processes, processPath)
 		d.processesMutex.Unlock()
 
+		defer func() {
+			if d.cleanupProcessDirsOnWait {
+				err := os.RemoveAll(processPath)
+				if err != nil {
+					log.Error("error-cleaning-up-process-dir", err, lager.Data{"processPath": processPath})
+				}
+			}
+		}()
+
 		if extraCleanup != nil {
 			if err := extraCleanup(); err != nil {
 				return err
 			}
-		}
-
-		if d.cleanupProcessDirsOnWait {
-			return os.RemoveAll(processPath)
 		}
 		return nil
 	}

--- a/rundmc/execrunner/dadoo/execrunner_linux_test.go
+++ b/rundmc/execrunner/dadoo/execrunner_linux_test.go
@@ -344,6 +344,24 @@ var _ = Describe("Dadoo ExecRunner", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(log.Buffer().Contents())).To(ContainSubstring("a-cleanup-error"))
 				})
+
+				Context("when cleanupProcessDirsOnWait is true", func() {
+					BeforeEach(func() {
+						runner = dadoo.NewExecRunner("path-to-dadoo", "path-to-runc", "runc-root",
+							signallerFactory, fakeCommandRunner, true, 5, 6, bundleSaver, bundleLookupper, processDepot)
+					})
+
+					It("doesn't leak process directories", func() {
+						proc, err := runner.RunPea(log, processID, goci.Bndl{}, "some-handle", defaultProcessIO(), false, bytes.NewBufferString("stdin"), func() error {
+							return errors.New("a-cleanup-error")
+						})
+						Expect(err).NotTo(HaveOccurred())
+						Expect(processPath).To(BeAnExistingFile())
+						_, err = proc.Wait()
+						Expect(err).NotTo(HaveOccurred())
+						Eventually(processPath).ShouldNot(BeAnExistingFile())
+					})
+				})
 			})
 		})
 
@@ -1017,6 +1035,23 @@ var _ = Describe("Dadoo ExecRunner", func() {
 					_, err = proc.Wait()
 					Expect(err).NotTo(HaveOccurred())
 					Expect(string(log.Buffer().Contents())).To(ContainSubstring("a-cleanup-error"))
+				})
+				Context("when cleanupProcessDirsOnWait is true", func() {
+					BeforeEach(func() {
+						runner = dadoo.NewExecRunner("path-to-dadoo", "path-to-runc", "runc-root",
+							signallerFactory, fakeCommandRunner, true, 5, 6, bundleSaver, bundleLookupper, processDepot)
+					})
+
+					It("doesn't leak process directories", func() {
+						proc, err := runner.RunPea(log, processID, goci.Bndl{}, "some-handle", defaultProcessIO(), false, bytes.NewBufferString("stdin"), func() error {
+							return errors.New("a-cleanup-error")
+						})
+						Expect(err).NotTo(HaveOccurred())
+						Expect(processPath).To(BeAnExistingFile())
+						_, err = proc.Wait()
+						Expect(err).NotTo(HaveOccurred())
+						Eventually(processPath).ShouldNot(BeAnExistingFile())
+					})
 				})
 			})
 		})


### PR DESCRIPTION
Guardian on Windows suffered from bugs preventing process directories from cleaning up after Wait() (both success + failures). It now uses the same logic as Guardian on Linux.

Guarian on Linux would fail to cleanup process directories on wait, if the extraCleanup() function failed. This is also resolved.