### PR TITLE
Pin otel/trace to v1.15.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ replace (
 
 	// force otel back to 1.15.1 since 1.16.0 is incompatible with containerd  1.7.1
 	go.opentelemetry.io/otel => go.opentelemetry.io/otel v1.15.1
+	go.opentelemetry.io/otel/trace => go.opentelemetry.io/otel/trace v1.15.1
 )
 
 require (


### PR DESCRIPTION
This is a follow up to:
- https://github.com/cloudfoundry/guardian/commit/4ce98fefbc9834cfcb6517cc92b1320aae4c8b8e

Prevents the following bug:
```
$ go get -t -u ./... && go mod tidy && go mod vendor && go vet ./...
vendor/go.opentelemetry.io/otel/internal/global/trace.go:56:30: cannot use &tracerProvider{} (value of type *tracerProvider) as trace.TracerProvider value in variable declaration: *tracerProvider does not implement trace.TracerProvider (missing method tracerProvider)
vendor/go.opentelemetry.io/otel/internal/global/trace.go:104:10: cannot use val (variable of type *tracer) as trace.Tracer value in return statement: *tracer does not implement trace.Tracer (missing method tracer)
vendor/go.opentelemetry.io/otel/internal/global/trace.go:109:9: cannot use t (variable of type *tracer) as trace.Tracer value in return statement: *tracer does not implement trace.Tracer (missing method tracer)
vendor/go.opentelemetry.io/otel/internal/global/trace.go:130:22: cannot use &tracer{} (value of type *tracer) as trace.Tracer value in variable declaration: *tracer does not implement trace.Tracer (missing method tracer)
vendor/go.opentelemetry.io/otel/internal/global/trace.go:151:35: cannot use s (variable of type nonRecordingSpan) as trace.Span value in argument to trace.ContextWithSpan: nonRecordingSpan does not implement trace.Span (missing method span)
vendor/go.opentelemetry.io/otel/internal/global/trace.go:163:20: cannot use nonRecordingSpan{} (value of type nonRecordingSpan) as trace.Span value in variable declaration: nonRecordingSpan does not implement trace.Span (missing method span)
vendor/go.opentelemetry.io/otel/internal/global/state.go:53:15: impossible type assertion: current.(*tracerProvider)
	*tracerProvider does not implement trace.TracerProvider (missing method tracerProvider)
vendor/go.opentelemetry.io/otel/internal/global/state.go:54:17: impossible type assertion: tp.(*tracerProvider)
	*tracerProvider does not implement trace.TracerProvider (missing method tracerProvider)
vendor/go.opentelemetry.io/otel/internal/global/state.go:66:17: impossible type assertion: current.(*tracerProvider)
	*tracerProvider does not implement trace.TracerProvider (missing method tracerProvider)
vendor/go.opentelemetry.io/otel/internal/global/state.go:107:35: cannot use &tracerProvider{} (value of type *tracerProvider) as trace.TracerProvider value in struct literal: *tracerProvider does not implement trace.TracerProvider (missing method tracerProvider)
vendor/go.opentelemetry.io/otel/internal/global/trace.go:151:35: too many errors
```