### PR TITLE
Provide better visibility into containers that cannot be killed

### DIFF
--- a/guardiancmd/cleanup.go
+++ b/guardiancmd/cleanup.go
@@ -6,9 +6,10 @@ type CleanupCommand struct {
 
 func (cmd *CleanupCommand) Execute(args []string) error {
 	log, _ := cmd.Logger.Logger("guardian-cleanup")
+	metricsProvider := cmd.wireMetricsProvider(log)
 	cmd.Containers.DestroyContainersOnStartup = true
 
-	wiring, err := cmd.createWiring(log)
+	wiring, err := cmd.createWiring(log, metricsProvider)
 	if err != nil {
 		return err
 	}

--- a/guardiancmd/server.go
+++ b/guardiancmd/server.go
@@ -234,7 +234,8 @@ func restoreUnversionedAssets(assetsDir string) (string, error) {
 
 func (cmd *ServerCommand) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
 	logger, reconfigurableSink := cmd.Logger.Logger("guardian")
-	wiring, err := cmd.createWiring(logger)
+	metricsProvider := cmd.wireMetricsProvider(logger)
+	wiring, err := cmd.createWiring(logger, metricsProvider)
 	if err != nil {
 		return err
 	}
@@ -262,8 +263,6 @@ func (cmd *ServerCommand) Run(signals <-chan os.Signal, ready chan<- struct{}) e
 
 	cmd.initializeDropsonde(logger)
 
-	metricsProvider := cmd.wireMetricsProvider(logger)
-
 	debugServerMetrics := map[string]func() int{
 		"numCPUS":       metricsProvider.NumCPU,
 		"numGoRoutines": metricsProvider.NumGoroutine,
@@ -273,7 +272,8 @@ func (cmd *ServerCommand) Run(signals <-chan os.Signal, ready chan<- struct{}) e
 	}
 
 	periodicMetronMetrics := map[string]func() int{
-		"DepotDirs": metricsProvider.DepotDirs,
+		"DepotDirs":            metricsProvider.DepotDirs,
+		"UnkillableContainers": metricsProvider.UnkillableContainers,
 	}
 
 	metronNotifier := cmd.wireMetronNotifier(logger, periodicMetronMetrics)

--- a/metrics/metrics_provider_test.go
+++ b/metrics/metrics_provider_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 
 	"code.cloudfoundry.org/guardian/metrics"
 	"code.cloudfoundry.org/lager/v3/lagertest"
@@ -45,5 +46,67 @@ var _ = Describe("MetricsProvider", func() {
 		Expect(m.LoopDevices()).To(Equal(0))
 		Expect(m.BackingStores()).To(Equal(0))
 		Expect(m.DepotDirs()).To(Equal(3))
+	})
+
+	Describe("UnkillableContainers", func() {
+		Context("when flagging that a container was unkillable", func() {
+			Describe("RegisterUnkillableContainer", func() {
+				It("increments the unkillableContainerCount", func() {
+					m.RegisterUnkillableContainer("my-container")
+					Expect(m.UnkillableContainers()).To(Equal(1))
+				})
+
+				It("increments based off container ID, not call-count", func() {
+					m.RegisterUnkillableContainer("my-container")
+					m.RegisterUnkillableContainer("my-container")
+					m.RegisterUnkillableContainer("my-container")
+					Expect(m.UnkillableContainers()).To(Equal(1))
+					m.RegisterUnkillableContainer("my-other-container")
+					Expect(m.UnkillableContainers()).To(Equal(2))
+				})
+
+				Describe("RegisterKillableContainer", func() {
+					It("decrements the unkillableContainerCount", func() {
+						m.RegisterUnkillableContainer("my-container")
+						Expect(m.UnkillableContainers()).To(Equal(1))
+						m.RegisterKillableContainer("my-container")
+						Expect(m.UnkillableContainers()).To(Equal(0))
+					})
+
+					It("is idempotent", func() {
+						m.RegisterUnkillableContainer("my-container")
+						Expect(m.UnkillableContainers()).To(Equal(1))
+						m.RegisterKillableContainer("my-container")
+						Expect(m.UnkillableContainers()).To(Equal(0))
+						m.RegisterKillableContainer("my-container")
+						Expect(m.UnkillableContainers()).To(Equal(0))
+					})
+
+					It("decrements based off container ID, not call-count", func() {
+						m.RegisterUnkillableContainer("my-container")
+						m.RegisterUnkillableContainer("my-other-container")
+						Expect(m.UnkillableContainers()).To(Equal(2))
+
+						m.RegisterKillableContainer("my-other-container")
+						Expect(m.UnkillableContainers()).To(Equal(1))
+					})
+
+				})
+
+				It("is thread safe", func() {
+					wg := sync.WaitGroup{}
+					for i := 0; i < 10; i++ {
+						wg.Add(1)
+						go func() {
+							m.RegisterUnkillableContainer("my-container")
+							m.RegisterKillableContainer("my-container")
+							wg.Done()
+						}()
+					}
+					wg.Wait()
+					Expect(m.UnkillableContainers()).To(Equal(0))
+				})
+			})
+		})
 	})
 })


### PR DESCRIPTION
When container processes get stuck blocked in kernel code (e.g. a connection disappears mid-write to an NFS volume store), the processes are unkillable even with `kill -9`.

This change adds the following:
- updated log messages when kill -9 has failed, indicating that the VM running garden must be rebooted.
- a new `UnkillableContainers` metric is emitted that can be used to determine if a VM has any containers that garden was unable to kill.