### PR TITLE
Improve external networker error message

### DIFF
--- a/netplugin/external_networker.go
+++ b/netplugin/external_networker.go
@@ -270,7 +270,7 @@ func (p *externalBinaryNetworker) exec(log lager.Logger, action, handle string,
 	logData := lager.Data{"action": action, "stdin": string(stdinBytes), "stderr": stderr.String(), "stdout": stdout.String()}
 	if err != nil {
 		log.Error("external-networker-result", err, logData)
-		return fmt.Errorf("external networker %s: %s", action, err)
+		return fmt.Errorf("external networker encountered an error running '%s' action: %s", action, err)
 	}
 
 	if outputData != nil && stdout.Len() > 0 {


### PR DESCRIPTION
The error message captures both the error and the action that led to the error. Because the most common action that causes this error is the 'down' action (meaning, network teardown), a common error message was 'external networker down,' leading many people to beleive that the entire vxlan-policy-agent was no longer running.

The new error message tries to make clear that 'down' is the action, to avoid this misunderstanding