### PR TITLE
Add ReadHeaderTimeout server option

### DIFF
--- a/guardiancmd/command.go
+++ b/guardiancmd/command.go
@@ -96,6 +96,8 @@ type CommonCommand struct {
 
 		Tag       string `hidden:"true" long:"tag" description:"Optional 2-character identifier used for namespacing global configuration."`
 		SkipSetup bool   `long:"skip-setup" description:"Skip the preparation part of the host that requires root privileges"`
+
+		ReadHeaderTimeout time.Duration `long:"read-header-timeout" description:"The amount of time allowed to read request headers"`
 	} `group:"Server Configuration"`
 
 	Containers struct {

--- a/guardiancmd/server.go
+++ b/guardiancmd/server.go
@@ -246,7 +246,7 @@ func (cmd *ServerCommand) Run(signals <-chan os.Signal, ready chan<- struct{}) e
 		listenAddr = cmd.Server.BindSocket
 	}
 
-	gardenServer := server.New(listenNetwork, listenAddr, cmd.Containers.DefaultGraceTime, backend, logger.Session("api"))
+	gardenServer := server.New(listenNetwork, listenAddr, cmd.Containers.DefaultGraceTime, cmd.Server.ReadHeaderTimeout, backend, logger.Session("api"))
 	// listen on the socket prior to serving, to ensure unix socket files are created and the healthcheck
 	// process can launch while the backend runs its cleanup. However, don't serve requests in gardenServer
 	// until the cleanup is complete


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
To use with https://github.com/cloudfoundry/garden/pull/118


Backward Compatibility
---------------
Breaking Change? **No**
