### PR TITLE
Fix test for golang 1.23

### DIFF
--- a/rundmc/goci/serialize_test.go
+++ b/rundmc/goci/serialize_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Bundle Serialization", func() {
 		bundleSaver          *goci.BundleSaver
 		notFoundRuntimeError = map[string]string{
 			"linux":   "no such file or directory",
-			"windows": "The system cannot find the path specified.",
+			"windows": "The system cannot find the file specified.",
 		}
 	)
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Fixes test assertion to match new error message returned in go 1.23.


Backward Compatibility
---------------
Breaking Change? no