### PR TITLE
Address integer overflows across guardian

### DIFF
--- a/gardener/gardener.go
+++ b/gardener/gardener.go
@@ -538,7 +538,8 @@ func (g *Gardener) checkMaxContainers(handles []string) error {
 		return nil
 	}
 
-	if len(handles) >= int(g.MaxContainers) {
+	// #nosec G115 - length will never be negative
+	if uint64(len(handles)) >= g.MaxContainers {
 		return errors.New("max containers reached")
 	}
 

--- a/gardener/volume_provider.go
+++ b/gardener/volume_provider.go
@@ -68,9 +68,10 @@ func (v *VolumeProvider) Create(log lager.Logger, spec garden.ContainerSpec) (sp
 	} else {
 		var err error
 		baseConfig, err = v.VolumeCreator.Create(log.Session("volume-creator"), spec.Handle, RootfsSpec{
-			RootFS:     rootFSURL,
-			Username:   spec.Image.Username,
-			Password:   spec.Image.Password,
+			RootFS:   rootFSURL,
+			Username: spec.Image.Username,
+			Password: spec.Image.Password,
+			// #nosec G115 - itnore int overflow for filesystem attrs as it would require 9 exabytes to cause an issue
 			QuotaSize:  int64(spec.Limits.Disk.ByteHard),
 			QuotaScope: spec.Limits.Disk.Scope,
 			Namespaced: !spec.Privileged,

--- a/guardiancmd/command.go
+++ b/guardiancmd/command.go
@@ -599,6 +599,7 @@ func (cmd *CommonCommand) wireContainerizer(
 
 	processDepot := execrunner.NewProcessDirDepot(depot)
 
+	// #nosec G115 - the uid/gidmappings lists are capped at maxint32 by idmapper, and should never be negative
 	execRunner := factory.WireExecRunner(runcRoot, uint32(uidMappings.Map(0)), uint32(gidMappings.Map(0)), bundleSaver, depot, processDepot)
 	wireExecerFunc := func(pidGetter runrunc.PidGetter) *runrunc.Execer {
 		return runrunc.NewExecer(depot, processBuilder, factory.WireMkdirer(), userLookupper, execRunner, pidGetter)
@@ -723,8 +724,9 @@ func (cmd *CommonCommand) idMappings() (idmapper.MappingList, idmapper.MappingLi
 	uidMappings := idmapper.MappingList{
 		{
 			ContainerID: 0,
-			HostID:      uint32(containerRootUID),
-			Size:        1,
+			// #nosec G115 - containerRootUID uses idmapper's logic which caps the Uid at MaxInt32, and should not be negative.
+			HostID: uint32(containerRootUID),
+			Size:   1,
 		},
 		{
 			ContainerID: 1,
@@ -735,8 +737,9 @@ func (cmd *CommonCommand) idMappings() (idmapper.MappingList, idmapper.MappingLi
 	gidMappings := idmapper.MappingList{
 		{
 			ContainerID: 0,
-			HostID:      uint32(containerRootGID),
-			Size:        1,
+			// #nosec G115 - containerRootGID uses idmapper's logic which caps the Gid at MaxInt32, and should not be negative.
+			HostID: uint32(containerRootGID),
+			Size:   1,
 		},
 		{
 			ContainerID: 1,
@@ -749,10 +752,12 @@ func (cmd *CommonCommand) idMappings() (idmapper.MappingList, idmapper.MappingLi
 
 func (cmd *CommonCommand) calculateDefaultMappingLengths(containerRootUID, containerRootGID int) {
 	if cmd.Containers.UIDMapLength == 0 {
+		// #nosec G115 - containerRootUID uses idmapper's logic which caps the Uid at MaxInt32, and should not be negative.
 		cmd.Containers.UIDMapLength = uint32(containerRootUID) - cmd.Containers.UIDMapStart
 	}
 
 	if cmd.Containers.GIDMapLength == 0 {
+		// #nosec G115 - containerRootUID uses idmapper's logic which caps the Uid at MaxInt32, and should not be negative.
 		cmd.Containers.GIDMapLength = uint32(containerRootGID) - cmd.Containers.GIDMapStart
 	}
 }

--- a/guardiancmd/kernel_min_version_checker.go
+++ b/guardiancmd/kernel_min_version_checker.go
@@ -47,27 +47,28 @@ func kernelVersionFromReleaseString(release string) (uint64, error) {
 		return 0, fmt.Errorf("malformed version: %s", release)
 	}
 
-	maj, err := strconv.ParseInt(parts[1], 10, 16)
+	maj, err := strconv.ParseUint(parts[1], 10, 16)
 	if err != nil {
 		return 0, err
 	}
 
-	var min int64
+	var min uint64
 	if parts[2] != "" {
-		min, err = strconv.ParseInt(parts[2], 10, 16)
+		min, err = strconv.ParseUint(parts[2], 10, 16)
 		if err != nil {
 			return 0, err
 		}
 	}
 
-	var patch int64
+	var patch uint64
 	if parts[3] != "" {
-		patch, err = strconv.ParseInt(parts[3], 10, 16)
+		patch, err = strconv.ParseUint(parts[3], 10, 16)
 		if err != nil {
 			return 0, err
 		}
 	}
 
+	// #nosec G115 - strconv.ParseUint validates all of these above
 	return kernelVersion(uint16(maj), uint16(min), uint16(patch)), nil
 }
 

--- a/kawasaki/configure/container.go
+++ b/kawasaki/configure/container.go
@@ -148,5 +148,6 @@ func exitStatus(err error) (uint32, error) {
 		return 2, exitErr
 	}
 
+	// #nosec G115 - waitstatus is a uint32 that could return -1 if  the program hadn't exited, but we've nsured that prior to calling exitStatus() and by checking ExitError()
 	return uint32(status.ExitStatus()), nil
 }

--- a/kawasaki/networker.go
+++ b/kawasaki/networker.go
@@ -177,6 +177,7 @@ func (n *Networker) Network(log lager.Logger, containerSpec garden.ContainerSpec
 
 // Capacity returns the number of subnets this network can host
 func (n *Networker) Capacity() uint64 {
+	// #nosec G115 - we would never have a negative pool of subnets
 	return uint64(n.subnetPool.Capacity())
 }
 

--- a/rundmc/bundlerules/mount_options_linux.go
+++ b/rundmc/bundlerules/mount_options_linux.go
@@ -22,6 +22,7 @@ func UnprivilegedMountFlagsGetter(path string) ([]string, error) {
 
 	var flags []string
 	for mask, flag := range unprivilegedFlags {
+		// #nosec G115 - all the flags we care about above are positive ints, so we don't need to worry about overflow here
 		if uint64(statfs.Flags)&mask == mask {
 			flags = append(flags, flag)
 		}

--- a/rundmc/containerizer.go
+++ b/rundmc/containerizer.go
@@ -351,6 +351,7 @@ func (c *Containerizer) Info(log lager.Logger, handle string) (spec.ActualContai
 	var cpuShares, limitInBytes uint64
 	if bundle.Resources() != nil {
 		cpuShares = *bundle.Resources().CPU.Shares
+		// #nosec G115 - limits should never be negative
 		limitInBytes = uint64(*bundle.Resources().Memory.Limit)
 	} else {
 		log.Debug("bundle-resources-is-nil", lager.Data{"bundle": bundle})

--- a/rundmc/execrunner/dadoo/winsize.go
+++ b/rundmc/execrunner/dadoo/winsize.go
@@ -26,7 +26,7 @@ func SetWinSize(f *os.File, ws garden.WindowSize) error {
 		uintptr(unsafe.Pointer(&struct {
 			Rows uint16
 			Cols uint16
-		}{Rows: uint16(ws.Rows), Cols: uint16(ws.Columns)})),
+		}{Rows: ws.Rows, Cols: ws.Columns})),
 		0, 0, 0,
 	)
 

--- a/rundmc/preparerootfs/prepare_linux.go
+++ b/rundmc/preparerootfs/prepare_linux.go
@@ -38,7 +38,7 @@ func prepare() {
 	var rootfsPath = flag.String("rootfsPath", "", "rootfs path to chroot into")
 	var uid = flag.Int("uid", 0, "uid to create directories as")
 	var gid = flag.Int("gid", 0, "gid to create directories as")
-	var perm = flag.Int("perm", 0755, "Mode to create the directory with")
+	var perm = flag.Uint("perm", 0755, "Mode to create the directory with")
 	var recreate = flag.Bool("recreate", false, "whether to delete the directory before (re-)creating it")
 
 	flag.Parse()
@@ -62,6 +62,7 @@ func prepare() {
 			rmdir(path)
 		}
 
+		// #nosec G115 - filemodes shouldn't be above 32bit anyway
 		mkdir(path, *uid, *gid, os.FileMode(*perm))
 	}
 }

--- a/rundmc/processes/builder.go
+++ b/rundmc/processes/builder.go
@@ -38,7 +38,9 @@ func (p *ProcBuilder) BuildProcess(bndl goci.Bndl, spec garden.ProcessSpec, user
 		ConsoleSize: console(spec),
 		Env:         p.envDeterminer.EnvFor(bndl, spec, user.Uid),
 		User: specs.User{
-			UID:            uint32(user.Uid),
+			// #nosec G115 - uids should be positive and 32bit on linux, but libcontainer uses an int for them
+			UID: uint32(user.Uid),
+			// #nosec G115 - gids should be positive and 32bit on linux, but libcontainer uses an int for them
 			GID:            uint32(user.Gid),
 			AdditionalGids: additionalGIDs,
 			Username:       spec.User,
@@ -96,6 +98,7 @@ func intersect(l1 []string, l2 []string) (result []string) {
 func toUint32Slice(slice []int) []uint32 {
 	result := []uint32{}
 	for _, i := range slice {
+		// #nosec G115 - uids should be positive and 32bit on linux, but libcontainer uses an int for them
 		result = append(result, uint32(i))
 	}
 	return result

--- a/rundmc/runcontainerd/runcontainerd.go
+++ b/rundmc/runcontainerd/runcontainerd.go
@@ -129,6 +129,7 @@ func (r *RunContainerd) Create(log lager.Logger, id string, bundle goci.Bndl, pi
 	containerRootUID := idmapper.MappingList(bundle.Spec.Linux.UIDMappings).Map(0)
 	containerRootGID := idmapper.MappingList(bundle.Spec.Linux.GIDMappings).Map(0)
 
+	// #nosec G115 - the uid/gidmappings lists are capped at maxint32 by idmapper, and should never be negative
 	err := r.containerManager.Create(log, id, &bundle.Spec, uint32(containerRootUID), uint32(containerRootGID), func() (io.Reader, io.Writer, io.Writer) { return pio.Stdin, pio.Stdout, pio.Stderr })
 	if err != nil {
 		return err

--- a/vendor/code.cloudfoundry.org/garden/container.go
+++ b/vendor/code.cloudfoundry.org/garden/container.go
@@ -176,8 +176,8 @@ type TTYSpec struct {
 }
 
 type WindowSize struct {
-	Columns int `json:"columns,omitempty"`
-	Rows    int `json:"rows,omitempty"`
+	Columns uint16 `json:"columns,omitempty"`
+	Rows    uint16 `json:"rows,omitempty"`
 }
 
 type ProcessIO struct {

--- a/vendor/code.cloudfoundry.org/idmapper/idmapping.go
+++ b/vendor/code.cloudfoundry.org/idmapper/idmapping.go
@@ -11,7 +11,7 @@ type MappingList []specs.LinuxIDMapping
 
 func (m MappingList) Map(id int) int {
 	for _, m := range m {
-		if delta := id - int(m.ContainerID); delta < int(m.Size) {
+		if delta := int(int64(id) - int64(m.ContainerID)); delta < int(m.Size) {
 			return int(m.HostID) + delta
 		}
 	}


### PR DESCRIPTION

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Many ignores to avoid changing public interfaces and work through issues caused by libcontainer using int, but garden + linux using uint32 for things.

Updated a few things for better types to avoid casting, or casting in the opposite direction for more safety



Backward Compatibility
---------------
Breaking Change?