### PR TITLE
Convert back to uint16 for window sizes

### DIFF
--- a/rundmc/execrunner/dadoo/winsize.go
+++ b/rundmc/execrunner/dadoo/winsize.go
@@ -24,8 +24,8 @@ func SetWinSize(f *os.File, ws garden.WindowSize) error {
 		uintptr(f.Fd()),
 		uintptr(syscall.TIOCSWINSZ),
 		uintptr(unsafe.Pointer(&struct {
-			Rows int
-			Cols int
+			Rows uint16
+			Cols uint16
 		}{Rows: ws.Rows, Cols: ws.Columns})),
 		0, 0, 0,
 	)


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
We want these as uint16, but needed to update garden as well.


Backward Compatibility
---------------
Breaking Change? no