### PR TITLE
In cgroups v2 we need to use different fields for memory

### DIFF
--- a/vendor/code.cloudfoundry.org/garden/container.go
+++ b/vendor/code.cloudfoundry.org/garden/container.go
@@ -283,6 +283,10 @@ type ContainerMemoryStat struct {
 	// A memory usage total which reports memory usage in the same way that limits are enforced.
 	// This value includes memory consumed by nested containers.
 	TotalUsageTowardLimit uint64
+	//cgroups v2
+	Anon       uint64 `json:"anon"`
+	File       uint64 `json:"file"`
+	SwapCached uint64 `json:"swapcached"`
 }
 
 type ContainerCPUStat struct {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Logic: file + anon + swap - inactive_file

this is similar to cgroups v1 but uses the correct field from runc events

Context: https://github.com/opencontainers/runc/pull/3933

Fixes: cloudfoundry/diego-release#995

Backward Compatibility
---------------
Breaking Change? **No**

