### PR TITLE
Allow rootfs to be imported as flat dir

### DIFF
--- a/bin/test.bash
+++ b/bin/test.bash
@@ -14,6 +14,21 @@ if ! grep securityfs /proc/self/mounts > /dev/null 2>&1 ; then
 fi
 apparmor_parser -r ../../jobs/garden/templates/config/garden-default
 
+garden_rootfs_ext="${GARDEN_TEST_ROOTFS##*.}"
+if [[ $garden_rootfs_ext != "tar" ]]; then
+   garden_rootfs_tar="$(dirname $GARDEN_TEST_ROOTFS)/garden-rootfs.tar"
+   tar -cf "$garden_rootfs_tar" -C $GARDEN_TEST_ROOTFS .
+   export GARDEN_TEST_ROOTFS=$garden_rootfs_tar
+fi
+
+garden_fuse_ext="${GARDEN_FUSE_TEST_ROOTFS##*.}"
+if [[ $garden_fuse_ext != "tar" ]]; then
+   garden_fuse_tar="$(dirname $GARDEN_FUSE_TEST_ROOTFS)/garden-fuse.tar"
+   tar -cf "$garden_fuse_tar" -C $GARDEN_FUSE_TEST_ROOTFS .
+   export GARDEN_FUSE_TEST_ROOTFS=$garden_fuse_tar
+fi
+
+
 # shellcheck disable=SC2068
 # Double-quoting array expansion here causes ginkgo to fail
 #runc

--- a/gqt/runtime_plugin_test.go
+++ b/gqt/runtime_plugin_test.go
@@ -123,7 +123,8 @@ var _ = Describe("Runtime Plugin", func() {
 					})
 
 					It("sets the memory limit", func() {
-						Expect(bundle.Linux.Resources.Unified["memory.max"]).To(Equal(fmt.Sprintf("%d", 1*1024*1024)))
+						value := int64(1 * 1024 * 1024)
+						Expect(*bundle.Linux.Resources.Memory.Limit).To(Equal(value))
 					})
 
 					It("sets the CPU weight", func() {

--- a/rundmc/bundlerules/limits_test.go
+++ b/rundmc/bundlerules/limits_test.go
@@ -192,28 +192,6 @@ var _ = Describe("LimitsRule", func() {
 			}
 		})
 
-		It("sets the correct memory limit in bundle resources", func() {
-			newBndl, err := bundlerules.Limits{}.Apply(goci.Bundle(), spec.DesiredContainerSpec{
-				Limits: garden.Limits{
-					Memory: garden.MemoryLimits{LimitInBytes: 4096},
-				},
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(newBndl.Resources().Unified["memory.max"]).To(Equal("4096"))
-		})
-
-		It("limits swap to regular memory limit in bundle resources", func() {
-			newBndl, err := bundlerules.Limits{}.Apply(goci.Bundle(), spec.DesiredContainerSpec{
-				Limits: garden.Limits{
-					Memory: garden.MemoryLimits{LimitInBytes: 4096},
-				},
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(newBndl.Resources().Unified["memory.swap.max"]).To(Equal("4096"))
-		})
-
 		Context("when swap limit is disabled", func() {
 			It("does not limit swap in bundle resources", func() {
 				limits := bundlerules.Limits{DisableSwapLimit: true}

--- a/rundmc/runrunc/stats_test.go
+++ b/rundmc/runrunc/stats_test.go
@@ -110,7 +110,10 @@ var _ = Describe("Stats", func() {
 								"writeback": 29,
 								"swap": 30,
 								"hierarchical_memsw_limit": 31,
-								"total_swap": 32
+								"total_swap": 32,
+								"file": 8,
+								"anon": 2,
+								"swapcached": 20
 							}
 						},
 						"pids": {
@@ -184,6 +187,9 @@ var _ = Describe("Stats", func() {
 				HierarchicalMemswLimit:  31,
 				TotalSwap:               32,
 				TotalUsageTowardLimit:   24,
+				File:                    8,
+				Anon:                    2,
+				SwapCached:              20,
 			}))
 		})
 

--- a/rundmc/stopper/resolver_test.go
+++ b/rundmc/stopper/resolver_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"code.cloudfoundry.org/guardian/rundmc/cgroups"
 	"code.cloudfoundry.org/guardian/rundmc/stopper"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -39,11 +40,19 @@ var _ = Describe("Resolver", func() {
 			stateJson, err := os.Create(filepath.Join(fakeStateDir, "some-handle", "state.json"))
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(json.NewEncoder(stateJson).Encode(map[string]interface{}{
-				"cgroup_paths": map[string]string{
-					"devices": "i-am-the-devices-cgroup-path",
-				},
-			})).To(Succeed())
+			if cgroups.IsCgroup2UnifiedMode() {
+				Expect(json.NewEncoder(stateJson).Encode(map[string]interface{}{
+					"cgroup_paths": map[string]string{
+						"": "i-am-the-devices-cgroup-path",
+					},
+				})).To(Succeed())
+			} else {
+				Expect(json.NewEncoder(stateJson).Encode(map[string]interface{}{
+					"cgroup_paths": map[string]string{
+						"devices": "i-am-the-devices-cgroup-path",
+					},
+				})).To(Succeed())
+			}
 			Expect(stateJson.Close()).To(Succeed())
 		})
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
registry-image export flat directory instead of a tarball. This will make it so that it can run with a flat directory

Update tests for cgroups-v2 to reflect the changes made for memory.



Backward Compatibility
---------------
Breaking Change? **No**
