### PR TITLE
fix static checks on lager

### DIFF
--- a/guardiancmd/lager_flag.go
+++ b/guardiancmd/lager_flag.go
@@ -34,8 +34,7 @@ func (f LagerFlag) Logger(component string) (lager.Logger, *lager.Reconfigurable
 		panic(fmt.Sprintf("unknown log level: %s", f.LogLevel))
 	}
 
-	var internalSink lager.Sink
-	internalSink = lager.NewPrettySink(os.Stdout, lager.DEBUG)
+	internalSink := lager.NewPrettySink(os.Stdout, lager.DEBUG)
 
 	logger := lager.NewLogger(component)
 


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
fix static checks on lager

`root@fc353076ebb3:/repo/scripts/docker# ./test.bash guardian
Setting up controllers for cgroup v2
Verifying: verify_go repo/src/guardian
go version go1.24.4 linux/amd64
Verifying: verify_go_version_match_bosh_release repo
Verifying: verify_gofmt repo/src/guardian
Verifying: verify_govet repo/src/guardian
Verifying: verify_staticcheck repo/src/guardian
`

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
