### PR TITLE
fix log level validation test

### DIFF
--- a/gqt/logging_test.go
+++ b/gqt/logging_test.go
@@ -84,7 +84,7 @@ var _ = Describe("garden server Logging", func() {
 			_, err := client.Create(garden.ContainerSpec{})
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(client, "1s").Should(gbytes.Say(`"log_level":0`))
+			Eventually(client, "1s").Should(gbytes.Say(`"level":"debug"`))
 		})
 
 		It("doesn't log spurious messages on start", func() {
@@ -105,11 +105,11 @@ var _ = Describe("garden server Logging", func() {
 		})
 
 		It("logs at info level", func() {
-			Eventually(client, "1s").Should(gbytes.Say(`"log_level":1`))
+			Eventually(client, "1s").Should(gbytes.Say(`"level":"info"`))
 		})
 
 		It("does not log at debug level", func() {
-			Consistently(client, "1s").ShouldNot(gbytes.Say(`"log_level":0`))
+			Consistently(client, "1s").ShouldNot(gbytes.Say(`"level":"debug"`))
 		})
 	})
 


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
fix log level validation test


Backward Compatibility
---------------
Breaking Change? **
[Uploading guardian.log…]()
No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
