### PR TITLE
retain the cgroups go mod version to v0.0.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,8 @@ replace (
 	code.cloudfoundry.org/garden => ../garden
 	code.cloudfoundry.org/grootfs => ../grootfs
 	code.cloudfoundry.org/idmapper => ../idmapper
-	github.com/cilium/ebpf v0.19.0 => github.com/cilium/ebpf v0.18.0
+	github.com/cilium/ebpf v0.19.0 => github.com/cilium/ebpf v0.17.3
 	github.com/jessevdk/go-flags => github.com/jessevdk/go-flags v1.4.0
-	github.com/opencontainers/cgroups v0.0.3 => github.com/opencontainers/cgroups v0.0.2
 )
 
 require (


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
periodic go mod bump updates the epbf version to v0.19.0, it breaks build binaries for runc.
the compatibility of runc points to v0.17.3 https://github.com/opencontainers/runc/blob/61fe4ac73a37d8ded4f523c9ed4f00323ae19c89/go.mod#L31

`cc -c -Wall -O0 -g -ggdb -rdynamic pwd.c
cc -static -o nstar nstar.o pwd.o
/
/repo/src/guardian/vendor/github.com/opencontainers/runc /
go build -trimpath -buildmode=pie  -tags "seccomp apparmor netgo osusergo" -ldflags "-X main.gitCommit=2fc2b8ca-dirty  -linkmode external -extldflags -static-pie " -o runc .
/
/repo/src/guardian/cmd/socket2me /
/
/repo/src/guardian/gqt/cmd/fake_runc_stderr /
/
/repo/src/grootfs /`


Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
