### PR TITLE
[RFC0038] Support IPv6 in hosts file compilation

### DIFF
--- a/gardener/container.go
+++ b/gardener/container.go
@@ -44,6 +44,7 @@ func (c *container) Info() (garden.ContainerInfo, error) {
 	defer log.Debug("finished")
 
 	containerIP, _ := c.propertyManager.Get(c.handle, ContainerIPKey)
+	containerIPv6, _ := c.propertyManager.Get(c.handle, ContainerIPv6Key)
 	hostIP, _ := c.propertyManager.Get(c.handle, BridgeIPKey)
 	externalIP, _ := c.propertyManager.Get(c.handle, ExternalIPKey)
 
@@ -70,6 +71,7 @@ func (c *container) Info() (garden.ContainerInfo, error) {
 	return garden.ContainerInfo{
 		State:         state,
 		ContainerIP:   containerIP,
+		ContainerIPv6: containerIPv6,
 		HostIP:        hostIP,
 		ExternalIP:    externalIP,
 		ContainerPath: actualContainerSpec.BundlePath,

--- a/gardener/gardener.go
+++ b/gardener/gardener.go
@@ -32,6 +32,7 @@ import (
 
 const ContainerInterfaceKey = "garden.network.interface"
 const ContainerIPKey = "garden.network.container-ip"
+const ContainerIPv6Key = "garden.network.container-ipv6"
 const BridgeIPKey = "garden.network.host-ip"
 const ExternalIPKey = "garden.network.external-ip"
 const MappedPortsKey = "garden.network.mapped-ports"

--- a/gqt/net_plugin_test.go
+++ b/gqt/net_plugin_test.go
@@ -312,7 +312,7 @@ var _ = Describe("Network plugin", func() {
 
 				Expect(containerProperties["foo"]).To(Equal("bar"))
 				Expect(containerProperties["garden.network.container-ip"]).To(Equal("10.255.10.10"))
-				Expect(containerProperties["garden.network.container-ip"]).To(Equal("2001:db8::1"))
+				Expect(containerProperties["garden.network.container-ipv6"]).To(Equal("2001:db8::1"))
 				Expect(containerProperties["garden.network.host-ip"]).To(Equal("255.255.255.255"))
 			})
 		})

--- a/gqt/net_plugin_test.go
+++ b/gqt/net_plugin_test.go
@@ -291,6 +291,31 @@ var _ = Describe("Network plugin", func() {
 			Expect(containerProperties["garden.network.container-ip"]).To(Equal("10.255.10.10"))
 			Expect(containerProperties["garden.network.host-ip"]).To(Equal("255.255.255.255"))
 		})
+
+		Context("and the properties contain ipv6 address", func() {
+			BeforeEach(func() {
+				pluginReturn = `{
+					"properties":{
+						"foo":"bar",
+						"garden.network.container-ip":"10.255.10.10",
+						"garden.network.container-ipv6":"2001:db8::1",
+						"garden.network.host-ip":"255.255.255.255"
+					}
+			  }`
+			})
+
+			It("persists the returned properties to the container's properties", func() {
+				info, err := container.Info()
+				Expect(err).NotTo(HaveOccurred())
+
+				containerProperties := info.Properties
+
+				Expect(containerProperties["foo"]).To(Equal("bar"))
+				Expect(containerProperties["garden.network.container-ip"]).To(Equal("10.255.10.10"))
+				Expect(containerProperties["garden.network.container-ip"]).To(Equal("2001:db8::1"))
+				Expect(containerProperties["garden.network.host-ip"]).To(Equal("255.255.255.255"))
+			})
+		})
 	})
 
 	Context("when the network plugin returns dns_servers", func() {

--- a/kawasaki/config_creator.go
+++ b/kawasaki/config_creator.go
@@ -30,6 +30,7 @@ type NetworkConfig struct {
 	BridgeName            string
 	BridgeIP              net.IP
 	ContainerIP           net.IP
+	ContainerIPv6         net.IP
 	ExternalIP            net.IP
 	Subnet                *net.IPNet
 	Mtu                   int

--- a/kawasaki/dns/hosts_file_compiler.go
+++ b/kawasaki/dns/hosts_file_compiler.go
@@ -16,6 +16,10 @@ func (h *HostsFileCompiler) Compile(log lager.Logger, ip, ipv6 net.IP, handle st
 		handle = handle[len(handle)-49:]
 	}
 	hostEntries := []string{"127.0.0.1 localhost"}
+	if ipv6 != nil {
+		hostEntries = append(hostEntries, fmt.Sprintf("::1 localhost"))
+	}
+
 	hostEntries = append(hostEntries, fmt.Sprintf("%s %s", ip, handle))
 
 	if ipv6 != nil {

--- a/kawasaki/dns/hosts_file_compiler.go
+++ b/kawasaki/dns/hosts_file_compiler.go
@@ -11,12 +11,17 @@ import (
 type HostsFileCompiler struct {
 }
 
-func (h *HostsFileCompiler) Compile(log lager.Logger, ip net.IP, handle string, additionalHostEntries []string) ([]byte, error) {
+func (h *HostsFileCompiler) Compile(log lager.Logger, ip, ipv6 net.IP, handle string, additionalHostEntries []string) ([]byte, error) {
 	if len(handle) > 49 {
 		handle = handle[len(handle)-49:]
 	}
 	hostEntries := []string{"127.0.0.1 localhost"}
 	hostEntries = append(hostEntries, fmt.Sprintf("%s %s", ip, handle))
+
+	if ipv6 != nil {
+		hostEntries = append(hostEntries, fmt.Sprintf("%s %s", ipv6, handle))
+	}
+
 	hostEntries = append(hostEntries, additionalHostEntries...)
 	contents := strings.Join(hostEntries, "\n")
 	contents = contents + "\n"

--- a/kawasaki/dns/hosts_file_compiler.go
+++ b/kawasaki/dns/hosts_file_compiler.go
@@ -17,7 +17,7 @@ func (h *HostsFileCompiler) Compile(log lager.Logger, ip, ipv6 net.IP, handle st
 	}
 	hostEntries := []string{"127.0.0.1 localhost"}
 	if ipv6 != nil {
-		hostEntries = append(hostEntries, fmt.Sprintf("::1 localhost"))
+		hostEntries = append(hostEntries, "::1 localhost")
 	}
 
 	hostEntries = append(hostEntries, fmt.Sprintf("%s %s", ip, handle))

--- a/kawasaki/kawasakifakes/fake_host_file_compiler.go
+++ b/kawasaki/kawasakifakes/fake_host_file_compiler.go
@@ -10,13 +10,14 @@ import (
 )
 
 type FakeHostFileCompiler struct {
-	CompileStub        func(lager.Logger, net.IP, string, []string) ([]byte, error)
+	CompileStub        func(lager.Logger, net.IP, net.IP, string, []string) ([]byte, error)
 	compileMutex       sync.RWMutex
 	compileArgsForCall []struct {
 		arg1 lager.Logger
 		arg2 net.IP
-		arg3 string
-		arg4 []string
+		arg3 net.IP
+		arg4 string
+		arg5 []string
 	}
 	compileReturns struct {
 		result1 []byte
@@ -30,26 +31,27 @@ type FakeHostFileCompiler struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeHostFileCompiler) Compile(arg1 lager.Logger, arg2 net.IP, arg3 string, arg4 []string) ([]byte, error) {
-	var arg4Copy []string
-	if arg4 != nil {
-		arg4Copy = make([]string, len(arg4))
-		copy(arg4Copy, arg4)
+func (fake *FakeHostFileCompiler) Compile(arg1 lager.Logger, arg2 net.IP, arg3 net.IP, arg4 string, arg5 []string) ([]byte, error) {
+	var arg5Copy []string
+	if arg5 != nil {
+		arg5Copy = make([]string, len(arg5))
+		copy(arg5Copy, arg5)
 	}
 	fake.compileMutex.Lock()
 	ret, specificReturn := fake.compileReturnsOnCall[len(fake.compileArgsForCall)]
 	fake.compileArgsForCall = append(fake.compileArgsForCall, struct {
 		arg1 lager.Logger
 		arg2 net.IP
-		arg3 string
-		arg4 []string
-	}{arg1, arg2, arg3, arg4Copy})
+		arg3 net.IP
+		arg4 string
+		arg5 []string
+	}{arg1, arg2, arg3, arg4, arg5Copy})
 	stub := fake.CompileStub
 	fakeReturns := fake.compileReturns
-	fake.recordInvocation("Compile", []interface{}{arg1, arg2, arg3, arg4Copy})
+	fake.recordInvocation("Compile", []interface{}{arg1, arg2, arg3, arg4, arg5Copy})
 	fake.compileMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -63,17 +65,17 @@ func (fake *FakeHostFileCompiler) CompileCallCount() int {
 	return len(fake.compileArgsForCall)
 }
 
-func (fake *FakeHostFileCompiler) CompileCalls(stub func(lager.Logger, net.IP, string, []string) ([]byte, error)) {
+func (fake *FakeHostFileCompiler) CompileCalls(stub func(lager.Logger, net.IP, net.IP, string, []string) ([]byte, error)) {
 	fake.compileMutex.Lock()
 	defer fake.compileMutex.Unlock()
 	fake.CompileStub = stub
 }
 
-func (fake *FakeHostFileCompiler) CompileArgsForCall(i int) (lager.Logger, net.IP, string, []string) {
+func (fake *FakeHostFileCompiler) CompileArgsForCall(i int) (lager.Logger, net.IP, net.IP, string, []string) {
 	fake.compileMutex.RLock()
 	defer fake.compileMutex.RUnlock()
 	argsForCall := fake.compileArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeHostFileCompiler) CompileReturns(result1 []byte, result2 error) {
@@ -105,8 +107,6 @@ func (fake *FakeHostFileCompiler) CompileReturnsOnCall(i int, result1 []byte, re
 func (fake *FakeHostFileCompiler) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.compileMutex.RLock()
-	defer fake.compileMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/kawasaki/resolv.go
+++ b/kawasaki/resolv.go
@@ -11,7 +11,7 @@ import (
 
 //counterfeiter:generate . HostFileCompiler
 type HostFileCompiler interface {
-	Compile(log lager.Logger, ip net.IP, handle string, additionalHostEntries []string) ([]byte, error)
+	Compile(log lager.Logger, ip, ipv6 net.IP, handle string, additionalHostEntries []string) ([]byte, error)
 }
 
 //counterfeiter:generate . ResolvCompiler
@@ -29,7 +29,9 @@ type ResolvConfigurer struct {
 func (d *ResolvConfigurer) Configure(log lager.Logger, cfg NetworkConfig, pid int) error {
 	log = log.Session("dns-resolve-configure")
 
-	containerHostsContents, err := d.HostsFileCompiler.Compile(log, cfg.ContainerIP, cfg.ContainerHandle, cfg.AdditionalHostEntries)
+	containerHostsContents, err := d.HostsFileCompiler.Compile(
+		log, cfg.ContainerIP, cfg.ContainerIPv6, cfg.ContainerHandle, cfg.AdditionalHostEntries)
+
 	if err != nil {
 		log.Error("compiling-hosts-file", err)
 		return err

--- a/kawasaki/resolv_test.go
+++ b/kawasaki/resolv_test.go
@@ -62,7 +62,7 @@ var _ = Describe("ResolvConfigurer", func() {
 		}
 
 		Expect(dnsResolv.Configure(log, networkConfig, 42)).To(Succeed())
-		_, _, _, additionalHostEntries := fakeHostsFileCompiler.CompileArgsForCall(0)
+		_, _, _, _, additionalHostEntries := fakeHostsFileCompiler.CompileArgsForCall(0)
 		Expect(additionalHostEntries).To(Equal([]string{
 			"1.2.3.4 foo",
 			"2.3.4.5 bar",
@@ -76,7 +76,7 @@ var _ = Describe("ResolvConfigurer", func() {
 		}
 
 		Expect(dnsResolv.Configure(log, networkConfig, 42)).To(Succeed())
-		_, ip, handle, _ := fakeHostsFileCompiler.CompileArgsForCall(0)
+		_, ip, _, handle, _ := fakeHostsFileCompiler.CompileArgsForCall(0)
 		Expect(ip).To(Equal(networkConfig.ContainerIP))
 		Expect(handle).To(Equal(networkConfig.ContainerHandle))
 	})
@@ -147,6 +147,23 @@ var _ = Describe("ResolvConfigurer", func() {
 			It("should return an error", func() {
 				Expect(dnsResolv.Configure(log, kawasaki.NetworkConfig{ContainerHandle: handle}, 42)).To(BeAssignableToTypeOf(&os.PathError{}))
 			})
+		})
+	})
+
+	Context("when ipv6 is provided", func() {
+		var networkConfig kawasaki.NetworkConfig
+		BeforeEach(func() {
+			networkConfig = kawasaki.NetworkConfig{
+				ContainerHandle: handle,
+				ContainerIPv6:   net.ParseIP("2001:db8::1"),
+			}
+		})
+
+		It("passes ip and handle to the hosts compiler", func() {
+			Expect(dnsResolv.Configure(log, networkConfig, 42)).To(Succeed())
+			_, _, ipv6, handle, _ := fakeHostsFileCompiler.CompileArgsForCall(0)
+			Expect(ipv6).To(Equal(networkConfig.ContainerIPv6))
+			Expect(handle).To(Equal(networkConfig.ContainerHandle))
 		})
 	})
 })

--- a/netplugin/external_networker.go
+++ b/netplugin/external_networker.go
@@ -105,15 +105,11 @@ func (p *externalBinaryNetworker) Network(log lager.Logger, containerSpec garden
 		NetIn:      containerSpec.NetIn,
 	}
 
-	log.Debug("external-binary-inputs", lager.Data{"inputs": inputs})
-
 	outputs := UpOutputs{}
 	err := p.exec(log, "up", containerSpec.Handle, inputs, &outputs)
 	if err != nil {
 		return err
 	}
-
-	log.Debug("external-binary-outputs", lager.Data{"outputs": outputs})
 
 	for k, v := range outputs.Properties {
 		p.configStore.Set(containerSpec.Handle, k, v)

--- a/netplugin/external_networker.go
+++ b/netplugin/external_networker.go
@@ -124,12 +124,14 @@ func (p *externalBinaryNetworker) Network(log lager.Logger, containerSpec garden
 	}
 
 	containerIP, ok := p.configStore.Get(containerSpec.Handle, gardener.ContainerIPKey)
+	containerIPv6, ok := p.configStore.Get(containerSpec.Handle, gardener.ContainerIPv6Key)
 	if ok {
 		log.Info("external-binary-write-dns-to-config", lager.Data{
 			"dnsServers": pluginNameservers,
 		})
 		cfg := kawasaki.NetworkConfig{
 			ContainerIP:           net.ParseIP(containerIP),
+			ContainerIPv6:         net.ParseIP(containerIPv6),
 			BridgeIP:              net.ParseIP(containerIP),
 			ContainerHandle:       containerSpec.Handle,
 			OperatorNameservers:   p.operatorNameservers,

--- a/netplugin/external_networker.go
+++ b/netplugin/external_networker.go
@@ -105,11 +105,15 @@ func (p *externalBinaryNetworker) Network(log lager.Logger, containerSpec garden
 		NetIn:      containerSpec.NetIn,
 	}
 
+	log.Info("external-binary-network", lager.Data{"cni-plugin-inputs": inputs})
+
 	outputs := UpOutputs{}
 	err := p.exec(log, "up", containerSpec.Handle, inputs, &outputs)
 	if err != nil {
 		return err
 	}
+
+	log.Info("external-binary-network", lager.Data{"cni-plugin-outputs": outputs})
 
 	for k, v := range outputs.Properties {
 		p.configStore.Set(containerSpec.Handle, k, v)

--- a/netplugin/external_networker.go
+++ b/netplugin/external_networker.go
@@ -105,7 +105,7 @@ func (p *externalBinaryNetworker) Network(log lager.Logger, containerSpec garden
 		NetIn:      containerSpec.NetIn,
 	}
 
-	log.Info("external-binary-network", lager.Data{"cni-plugin-inputs": inputs})
+	log.Debug("external-binary-inputs", lager.Data{"inputs": inputs})
 
 	outputs := UpOutputs{}
 	err := p.exec(log, "up", containerSpec.Handle, inputs, &outputs)
@@ -113,7 +113,7 @@ func (p *externalBinaryNetworker) Network(log lager.Logger, containerSpec garden
 		return err
 	}
 
-	log.Info("external-binary-network", lager.Data{"cni-plugin-outputs": outputs})
+	log.Debug("external-binary-outputs", lager.Data{"outputs": outputs})
 
 	for k, v := range outputs.Properties {
 		p.configStore.Set(containerSpec.Handle, k, v)
@@ -128,7 +128,9 @@ func (p *externalBinaryNetworker) Network(log lager.Logger, containerSpec garden
 	}
 
 	containerIP, ok := p.configStore.Get(containerSpec.Handle, gardener.ContainerIPKey)
-	containerIPv6, ok := p.configStore.Get(containerSpec.Handle, gardener.ContainerIPv6Key)
+
+	// ipv6 address is "" if not returned by external networker
+	containerIPv6, _ := p.configStore.Get(containerSpec.Handle, gardener.ContainerIPv6Key)
 	if ok {
 		log.Info("external-binary-write-dns-to-config", lager.Data{
 			"dnsServers": pluginNameservers,

--- a/netplugin/external_networker_test.go
+++ b/netplugin/external_networker_test.go
@@ -480,6 +480,18 @@ var _ = Describe("ExternalNetworker", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
+
+		Context("when the external network plugin returns ipv6 address", func() {
+			It("persists the returned ipv6 address in the container's properties", func() {
+				pluginOutput = `{"properties":{"foo":"bar","ping":"pong","garden.network.container-ip":"10.255.1.2", "garden.network.container-ipv6":"2006:db8::1"}}`
+
+				err := plugin.Network(logger, containerSpec, 42)
+				Expect(err).NotTo(HaveOccurred())
+
+				persistedPropertyValue, _ := configStore.Get("some-handle", "garden.network.container-ipv6")
+				Expect(persistedPropertyValue).To(Equal("2006:db8::1"))
+			})
+		})
 	})
 
 	Describe("Destroy", func() {

--- a/vendor/code.cloudfoundry.org/garden/container.go
+++ b/vendor/code.cloudfoundry.org/garden/container.go
@@ -224,6 +224,7 @@ type ContainerInfo struct {
 	Events        []string      // List of events that occurred for the container. It currently includes only "oom" (Out Of Memory) event if it occurred.
 	HostIP        string        // The IP address of the gateway which controls the host side of the container's virtual ethernet pair.
 	ContainerIP   string        // The IP address of the container side of the container's virtual ethernet pair.
+	ContainerIPv6 string        // The IPv6 address of the container side of the container's virtual ethernet pair.
 	ExternalIP    string        //
 	ContainerPath string        // The path to the directory holding the container's files (both its control scripts and filesystem).
 	ProcessIDs    []string      // List of running processes.


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
[RFC0038](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0038-ipv6-dual-stack-for-cf.md)
[Tracking Issue](https://github.com/cloudfoundry/community/issues/1107)

Add IPv6 support to /etc/hosts compilation
Example hosts file after the change, when IPv6 is enabled:
```shell
vcap@a2df59ce-163d-478a-4799-902f:~$ cat /etc/hosts
127.0.0.1 localhost
::1 localhost
10.147.240.5 a2df59ce-163d-478a-4799-902f
2600:1f18:75b9:1c1e:2::5 a2df59ce-163d-478a-4799-902f
```


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
