### PR TITLE
configs.cgroup remove deprecated method

### DIFF
--- a/rundmc/cgroups/cpucgrouper_linux.go
+++ b/rundmc/cgroups/cpucgrouper_linux.go
@@ -8,7 +8,6 @@ import (
 	"github.com/opencontainers/cgroups"
 	"github.com/opencontainers/cgroups/fs"
 	"github.com/opencontainers/cgroups/fs2"
-	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 type CPUCgrouper struct {
@@ -70,7 +69,7 @@ func readCPUstatsFromPath(path string) (cgroups.Stats, error) {
 	stats := &cgroups.Stats{}
 
 	if cgroups.IsCgroup2UnifiedMode() {
-		cgroupManager, err := fs2.NewManager(&configs.Cgroup{}, path)
+		cgroupManager, err := fs2.NewManager(&cgroups.Cgroup{}, path)
 		if err != nil {
 			return cgroups.Stats{}, err
 		}

--- a/rundmc/runcontainerd/cgroup_manager_linux.go
+++ b/rundmc/runcontainerd/cgroup_manager_linux.go
@@ -7,7 +7,6 @@ import (
 	"code.cloudfoundry.org/guardian/rundmc/goci"
 	"github.com/opencontainers/cgroups"
 	"github.com/opencontainers/cgroups/fs2"
-	"github.com/opencontainers/runc/libcontainer/configs"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -22,11 +21,11 @@ func (m cgroupManager) setUnifiedResources(bundle goci.Bndl) error {
 
 		resources := convertSpecResourcesToCgroupResources(bundle.Spec.Linux.Resources)
 		if resources != nil {
-			cgroupManager, err := fs2.NewManager(&configs.Cgroup{}, cgroupPath)
+			cgroupManager, err := fs2.NewManager(&cgroups.Cgroup{}, cgroupPath)
 			if err != nil {
 				return err
 			}
-			err = fs2.CreateCgroupPath(cgroupPath, &configs.Cgroup{})
+			err = fs2.CreateCgroupPath(cgroupPath, &cgroups.Cgroup{})
 			if err != nil {
 				return err
 			}
@@ -42,12 +41,12 @@ func (m cgroupManager) setUnifiedResources(bundle goci.Bndl) error {
 	return nil
 }
 
-func convertSpecResourcesToCgroupResources(specResources *specs.LinuxResources) *configs.Resources {
+func convertSpecResourcesToCgroupResources(specResources *specs.LinuxResources) *cgroups.Resources {
 	if specResources == nil {
 		return nil
 	}
 
-	resources := &configs.Resources{}
+	resources := &cgroups.Resources{}
 	resources.Unified = specResources.Unified
 
 	if specResources.CPU != nil {


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
remove deprecated configs.cgroup constrct.

deprecated:
https://github.com/opencontainers/runc/blob/6a3f8ea3b4f6cc6af8f2d413e1853e465b2ebbdc/libcontainer/configs/cgroup_deprecated.go

recommended:

https://github.com/opencontainers/cgroups/blob/main/config_linux.go

error:

```
rundmc/cgroups/cpucgrouper_linux.go:73:41: configs.Cgroup is deprecated: use [github.com/opencontainers/cgroups].  (SA1019)
rundmc/runcontainerd/cgroup_manager_linux.go:25:42: configs.Cgroup is deprecated: use [github.com/opencontainers/cgroups].  (SA1019)
rundmc/runcontainerd/cgroup_manager_linux.go:29:44: configs.Cgroup is deprecated: use [github.com/opencontainers/cgroups].  (SA1019)
rundmc/runcontainerd/cgroup_manager_linux.go:45:82: configs.Resources is deprecated: use [github.com/opencontainers/cgroups].  (SA1019)
rundmc/runcontainerd/cgroup_manager_linux.go:50:16: configs.Resources is deprecated: use [github.com/opencontainers/cgroups].  (SA1019)
```

Test:

```
Verifying: verify_go repo/$DIR
go version go1.25.1 linux/amd64
Verifying: verify_go_version_match_bosh_release repo
Verifying: verify_gofmt repo/$DIR
Verifying: verify_govet repo/$DIR
Verifying: verify_staticcheck repo/$DIR
2025/09/16 21:55:34 maxprocs: Leaving GOMAXPROCS=16: CPU quota undefined
```


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
