### PR TITLE
Don't report network metrics on healthcheck containers.

### DIFF
--- a/gardener/container_network_metrics_provider_linux.go
+++ b/gardener/container_network_metrics_provider_linux.go
@@ -103,6 +103,10 @@ func NewLinuxContainerNetworkMetricsProvider(
 func (l *LinuxContainerNetworkMetricsProvider) Get(log lager.Logger, handle string) (*garden.ContainerNetworkStat, error) {
 	log = log.Session("container-network-metrics")
 
+	if isHealthcheck, found := l.propertyManager.Get(handle, "network.healthcheck"); found && isHealthcheck == "true" {
+		return nil, nil
+	}
+
 	ifName, found := l.propertyManager.Get(handle, ContainerInterfaceKey)
 	if !found || ifName == "" {
 		return nil, nil

--- a/gardener/container_network_metrics_provider_linux_test.go
+++ b/gardener/container_network_metrics_provider_linux_test.go
@@ -106,6 +106,23 @@ var _ = Describe("LinuxContainerNetworkMetricsProvider", func() {
 			Expect(actualNetworkMetrics.RxBytes).To(BeNumerically("~", 4096, 1000))
 		})
 
+		Context("when the container is a healthcheck container", func() {
+			BeforeEach(func() {
+				propertyManager.GetStub = func(h string, key string) (string, bool) {
+					if key == "network.healthcheck" {
+						return "true", true
+					}
+					return linkName, true
+				}
+			})
+
+			It("should return nil", func() {
+				actualNetworkMetrics, err := networkMetricsProvider.Get(logger, handle)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(actualNetworkMetrics).To(BeNil())
+			})
+		})
+
 		Context("when the network interface name is not stored in the property manager", func() {
 			BeforeEach(func() {
 				propertyManager.GetReturns("", false)


### PR DESCRIPTION


- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Previously, if healthcheck containers did not have an eth0 interface due to being health check containers not needing networking, and CNIs skipping that step, an error is returned from Garden when getting BulkMetrics for the container.

In practice this breaks rep's ability to calculate the rootfs size for preloaded rootfses, since it calls GetBulkMetrics on a dummy container created with "network.healthcheck": "true" set, and tries to look at the disk metrics returned from Garden. Since garden returns the error, the disk metrics are set to zero, and error is discarded during startup to allow apps to at least work, even if their disk quota is inaccurate.

Now we will return no error, and zero/nil for network metrics. BulkMetrics will return the disk size to rep, and everything will behave as normal when calculating the rootfs sizes.

TNZ-92752
ai-assisted=yes


Backward Compatibility
---------------
Breaking Change? no
