### PR TITLE
make nstar compile on Resolute

### DIFF
--- a/rundmc/nstar/nstar.c
+++ b/rundmc/nstar/nstar.c
@@ -17,7 +17,11 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 #include <linux/sched.h>
-#include <linux/fcntl.h>
+#include <fcntl.h>
+
+#ifndef AT_EMPTY_PATH
+#define AT_EMPTY_PATH 0x1000
+#endif
 
 #include "pwd.h"
 


### PR DESCRIPTION
This is a PoC fix for making nstar compile on a Resolute Raccoon stemcell
