### PR TITLE
Enable NoNewPrivileges for unprivileged container processes

### DIFF
--- a/gqt/runner/runner.go
+++ b/gqt/runner/runner.go
@@ -96,6 +96,7 @@ type GdnRunnerConfig struct {
 	CleanupProcessDirsOnWait       *bool    `flag:"cleanup-process-dirs-on-wait"`
 	DisablePrivilegedContainers    *bool    `flag:"disable-privileged-containers"`
 	AppArmor                       string   `flag:"apparmor"`
+	NoNewPrivileges                *bool    `flag:"no-new-privileges"`
 	Tag                            string   `flag:"tag"`
 	NetworkPool                    string   `flag:"network-pool"`
 	ContainerdSocket               string   `flag:"containerd-socket"`

--- a/gqt/security_test.go
+++ b/gqt/security_test.go
@@ -160,6 +160,111 @@ var _ = Describe("Security", func() {
 		})
 	})
 
+	Describe("NoNewPrivileges", func() {
+		Context("when the --no-new-privileges flag is set", func() {
+			BeforeEach(func() {
+				config.NoNewPrivileges = boolptr(true)
+			})
+
+			Context("when running processes in unprivileged containers", func() {
+				var (
+					container garden.Container
+					err       error
+				)
+
+				JustBeforeEach(func() {
+					container, err = client.Create(garden.ContainerSpec{})
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should set NoNewPrivileges on the process", func() {
+					buffer := gbytes.NewBuffer()
+
+					_, err = container.Run(garden.ProcessSpec{
+						Path: "grep",
+						Args: []string{"NoNewPrivs", "/proc/self/status"},
+					}, garden.ProcessIO{
+						Stdout: io.MultiWriter(GinkgoWriter, buffer),
+						Stderr: GinkgoWriter,
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(buffer).Should(gbytes.Say(`NoNewPrivs:\s+1`))
+				})
+
+				Context("when running a pea", func() {
+					var peaRootfs string
+
+					BeforeEach(func() {
+						peaRootfs = createPeaRootfsTar()
+					})
+
+					AfterEach(func() {
+						Expect(os.RemoveAll(filepath.Dir(peaRootfs))).To(Succeed())
+					})
+
+					It("should set NoNewPrivileges on the process", func() {
+						buffer := gbytes.NewBuffer()
+
+						_, err = container.Run(garden.ProcessSpec{
+							Path:  "grep",
+							Args:  []string{"NoNewPrivs", "/proc/self/status"},
+							Image: garden.ImageRef{URI: peaRootfs},
+						}, garden.ProcessIO{
+							Stdout: io.MultiWriter(GinkgoWriter, buffer),
+							Stderr: GinkgoWriter,
+						})
+						Expect(err).NotTo(HaveOccurred())
+
+						Eventually(buffer).Should(gbytes.Say(`NoNewPrivs:\s+1`))
+					})
+				})
+			})
+
+			Context("when running processes in privileged containers", func() {
+				It("should not set NoNewPrivileges", func() {
+					container, err := client.Create(garden.ContainerSpec{
+						Privileged: true,
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					buffer := gbytes.NewBuffer()
+
+					_, err = container.Run(garden.ProcessSpec{
+						Path: "grep",
+						Args: []string{"NoNewPrivs", "/proc/self/status"},
+					}, garden.ProcessIO{
+						Stdout: io.MultiWriter(GinkgoWriter, buffer),
+						Stderr: GinkgoWriter,
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(buffer).Should(gbytes.Say(`NoNewPrivs:\s+0`))
+				})
+			})
+		})
+
+		Context("when the --no-new-privileges flag is not set", func() {
+			It("should not set NoNewPrivileges on processes in unprivileged containers", func() {
+				container, err := client.Create(garden.ContainerSpec{})
+				Expect(err).NotTo(HaveOccurred())
+
+				buffer := gbytes.NewBuffer()
+
+				_, err = container.Run(garden.ProcessSpec{
+					Path: "grep",
+					Args: []string{"NoNewPrivs", "/proc/self/status"},
+				}, garden.ProcessIO{
+					Stdout: io.MultiWriter(GinkgoWriter, buffer),
+					Stderr: GinkgoWriter,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(buffer).Should(gbytes.Say(`NoNewPrivs:\s+0`))
+			})
+		})
+	})
+
 	Describe("ptrace in seccomp allow rules", func() {
 		It("should allow the ptrace syscall without CAP_SYS_PTRACE", func() {
 			container, err := client.Create(garden.ContainerSpec{

--- a/guardiancmd/command.go
+++ b/guardiancmd/command.go
@@ -117,6 +117,7 @@ type CommonCommand struct {
 		DefaultGraceTime           time.Duration `long:"default-grace-time" description:"Default time after which idle containers should expire."`
 		DestroyContainersOnStartup bool          `long:"destroy-containers-on-startup" description:"Clean up all the existing containers on startup."`
 		ApparmorProfile            string        `long:"apparmor" description:"Apparmor profile to use for unprivileged container processes"`
+		NoNewPrivileges            bool          `long:"no-new-privileges" description:"Set NoNewPrivileges on unprivileged container processes"`
 	} `group:"Container Lifecycle"`
 
 	Bin struct {
@@ -526,6 +527,12 @@ func (cmd *CommonCommand) wireContainerizer(
 		return nil, nil, err
 	}
 	unprivilegedBundle.Spec.Linux.Seccomp = seccomp
+
+	if cmd.Containers.NoNewPrivileges {
+		unprivilegedBundle = unprivilegedBundle.
+			WithNoNewPrivileges().
+			WithPingGroupRange()
+	}
 
 	if cmd.Containers.ApparmorProfile != "" {
 		unprivilegedBundle = unprivilegedBundle.WithApparmorProfile(cmd.Containers.ApparmorProfile)

--- a/rundmc/goci/bundle.go
+++ b/rundmc/goci/bundle.go
@@ -75,20 +75,24 @@ func (b Bndl) WithNoNewPrivileges() Bndl {
 	return b
 }
 
-// WithPingGroupRange permits all non-root GIDs to use unprivileged ICMP
-// sockets (SOCK_DGRAM IPPROTO_ICMP) inside the container. This restores the
-// ability to run ping when NoNewPrivileges is set, since NNP causes file
+// WithPingGroupRange permits container GIDs in [1, 65535] to use unprivileged
+// ICMP sockets (SOCK_DGRAM IPPROTO_ICMP) inside the container. This restores
+// the ability to run ping when NoNewPrivileges is set, since NNP causes file
 // capabilities (cap_net_raw on /bin/ping) to be dropped on exec.
 //
-// The range is bounded by the container's user namespace GID mapping. GID 0
-// is excluded because in an unprivileged userns it maps to the host overflow
-// GID; the upper bound stays well inside the mapping (which extends to
-// 4294901757) so kernel make_kgid translation succeeds.
+// The kernel writes this sysctl by translating each GID through the writer's
+// user namespace mapping; the resulting kernel GIDs must (a) both be valid
+// for that userns and (b) satisfy low <= high, otherwise the value is
+// rejected with EINVAL or silently reset to the "disabled" sentinel "1 0".
+// GID 0 is excluded because in an unprivileged userns it maps to the host
+// overflow GID and inverts the range. 65535 is small enough to translate
+// cleanly under any reasonable userns mapping while still covering every
+// realistic container GID (e.g. vcap=2000).
 func (b Bndl) WithPingGroupRange() Bndl {
 	if b.Spec.Linux.Sysctl == nil {
 		b.CloneLinux().Spec.Linux.Sysctl = map[string]string{}
 	}
-	b.Spec.Linux.Sysctl["net.ipv4.ping_group_range"] = "1 2147483647"
+	b.Spec.Linux.Sysctl["net.ipv4.ping_group_range"] = "1 65535"
 	return b
 }
 

--- a/rundmc/goci/bundle.go
+++ b/rundmc/goci/bundle.go
@@ -70,6 +70,28 @@ func (b Bndl) WithApparmorProfile(profile string) Bndl {
 	return b
 }
 
+func (b Bndl) WithNoNewPrivileges() Bndl {
+	b.CloneProcess().Spec.Process.NoNewPrivileges = true
+	return b
+}
+
+// WithPingGroupRange permits all non-root GIDs to use unprivileged ICMP
+// sockets (SOCK_DGRAM IPPROTO_ICMP) inside the container. This restores the
+// ability to run ping when NoNewPrivileges is set, since NNP causes file
+// capabilities (cap_net_raw on /bin/ping) to be dropped on exec.
+//
+// The range is bounded by the container's user namespace GID mapping. GID 0
+// is excluded because in an unprivileged userns it maps to the host overflow
+// GID; the upper bound stays well inside the mapping (which extends to
+// 4294901757) so kernel make_kgid translation succeeds.
+func (b Bndl) WithPingGroupRange() Bndl {
+	if b.Spec.Linux.Sysctl == nil {
+		b.CloneLinux().Spec.Linux.Sysctl = map[string]string{}
+	}
+	b.Spec.Linux.Sysctl["net.ipv4.ping_group_range"] = "1 2147483647"
+	return b
+}
+
 func (b Bndl) WithRootFS(absolutePath string) Bndl {
 	b.Spec.Root = &specs.Root{Path: absolutePath}
 	return b

--- a/rundmc/goci/bundle_test.go
+++ b/rundmc/goci/bundle_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Bundle", func() {
 	Describe("WithPingGroupRange", func() {
 		It("sets net.ipv4.ping_group_range to the permissive range", func() {
 			returnedBundle := initialBundle.WithPingGroupRange()
-			Expect(returnedBundle.Spec.Linux.Sysctl).To(HaveKeyWithValue("net.ipv4.ping_group_range", "1 2147483647"))
+			Expect(returnedBundle.Spec.Linux.Sysctl).To(HaveKeyWithValue("net.ipv4.ping_group_range", "1 65535"))
 		})
 
 		It("does not modify the initial bundle", func() {
@@ -99,7 +99,7 @@ var _ = Describe("Bundle", func() {
 			It("preserves the existing sysctls", func() {
 				returnedBundle := initialBundle.WithPingGroupRange()
 				Expect(returnedBundle.Spec.Linux.Sysctl).To(HaveKeyWithValue("net.ipv4.tcp_keepalive_time", "60"))
-				Expect(returnedBundle.Spec.Linux.Sysctl).To(HaveKeyWithValue("net.ipv4.ping_group_range", "1 2147483647"))
+				Expect(returnedBundle.Spec.Linux.Sysctl).To(HaveKeyWithValue("net.ipv4.ping_group_range", "1 65535"))
 			})
 		})
 	})

--- a/rundmc/goci/bundle_test.go
+++ b/rundmc/goci/bundle_test.go
@@ -66,6 +66,44 @@ var _ = Describe("Bundle", func() {
 		})
 	})
 
+	Describe("WithNoNewPrivileges", func() {
+		It("sets NoNewPrivileges on the process", func() {
+			returnedBundle := initialBundle.WithNoNewPrivileges()
+			Expect(returnedBundle.Spec.Process.NoNewPrivileges).To(BeTrue())
+		})
+
+		It("does not modify the initial bundle", func() {
+			initialBundle.WithNoNewPrivileges()
+			Expect(initialBundle.Spec.Process.NoNewPrivileges).To(BeFalse())
+		})
+	})
+
+	Describe("WithPingGroupRange", func() {
+		It("sets net.ipv4.ping_group_range to the permissive range", func() {
+			returnedBundle := initialBundle.WithPingGroupRange()
+			Expect(returnedBundle.Spec.Linux.Sysctl).To(HaveKeyWithValue("net.ipv4.ping_group_range", "1 2147483647"))
+		})
+
+		It("does not modify the initial bundle", func() {
+			initialBundle.WithPingGroupRange()
+			Expect(initialBundle.Spec.Linux.Sysctl).NotTo(HaveKey("net.ipv4.ping_group_range"))
+		})
+
+		Context("when the bundle already has other sysctls", func() {
+			BeforeEach(func() {
+				initialBundle.Spec.Linux.Sysctl = map[string]string{
+					"net.ipv4.tcp_keepalive_time": "60",
+				}
+			})
+
+			It("preserves the existing sysctls", func() {
+				returnedBundle := initialBundle.WithPingGroupRange()
+				Expect(returnedBundle.Spec.Linux.Sysctl).To(HaveKeyWithValue("net.ipv4.tcp_keepalive_time", "60"))
+				Expect(returnedBundle.Spec.Linux.Sysctl).To(HaveKeyWithValue("net.ipv4.ping_group_range", "1 2147483647"))
+			})
+		})
+	})
+
 	Describe("WithProcess", func() {
 		It("adds the process to the bundle", func() {
 			returnedBundle := initialBundle.WithProcess(goci.Process("echo", "foo"))

--- a/rundmc/processes/builder.go
+++ b/rundmc/processes/builder.go
@@ -53,6 +53,7 @@ func (p *ProcBuilder) BuildProcess(bndl goci.Bndl, spec garden.ProcessSpec, user
 		Rlimits:         toRlimits(spec.Limits),
 		Terminal:        spec.TTY != nil,
 		ApparmorProfile: bndl.Process().ApparmorProfile,
+		NoNewPrivileges: bndl.Process().NoNewPrivileges,
 	}
 }
 

--- a/rundmc/processes/builder_test.go
+++ b/rundmc/processes/builder_test.go
@@ -196,6 +196,20 @@ var _ = Describe("ProcBuilder", func() {
 					Expect(preparedProc.ApparmorProfile).To(Equal("default-profile"))
 				})
 
+				It("passes NoNewPrivileges from the bundle", func() {
+					Expect(preparedProc.NoNewPrivileges).To(BeFalse())
+				})
+
+				Context("when the bundle has NoNewPrivileges set", func() {
+					BeforeEach(func() {
+						bndl.Spec.Process.NoNewPrivileges = true
+					})
+
+					It("propagates NoNewPrivileges to the process", func() {
+						Expect(preparedProc.NoNewPrivileges).To(BeTrue())
+					})
+				})
+
 				It("passes the UID, GID and SGIDs", func() {
 					Expect(preparedProc.User.UID).To(Equal(uint32(1)))
 					Expect(preparedProc.User.GID).To(Equal(uint32(2)))


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Adds `--no-new-privileges` flag that sets `NoNewPrivileges=true` in the OCI runtime spec for unprivileged containers and peas, closing a privilege escalation path via setuid binaries. The flag is propagated to all spawned processes including `cf ssh` and sidecars. Privileged containers are unaffected.

Because `NoNewPrivileges` strips file capabilities (notably `cap_net_raw` on `/bin/ping`) at exec, this also sets `net.ipv4.ping_group_range = "1 65535"` on the unprivileged bundle so containers can still use ICMP via unprivileged sockets (`SOCK_DGRAM IPPROTO_ICMP`). The upper bound is intentionally small to translate cleanly under any reasonable user-namespace GID mapping; values closer to `INT_MAX` were observed to fail kernel validation in some userns configurations.

Test Results
---------------
Validated end-to-end on a CF deployment. Both buildpack and Docker apps:

- container init has `NoNewPrivs: 1`
- `net.ipv4.ping_group_range` reads `1   65535` inside the container's netns
- `ping 8.8.8.8` succeeds with the unprivileged user

**Go buildpack app (vcap, gid 2000):**
```
vcap@fde7e5d0-d3ae-4027-56a5-9e5a:~$ grep NoNewPrivs /proc/self/status; cat /proc/sys/net/ipv4/ping_group_range; id; ping -c 2 8.8.8.8
NoNewPrivs:    1
1    65535
uid=2000(vcap) gid=2000(vcap) groups=2000(vcap)
PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
64 bytes from 8.8.8.8: icmp_seq=1 ttl=111 time=1.75 ms
64 bytes from 8.8.8.8: icmp_seq=2 ttl=111 time=1.19 ms

--- 8.8.8.8 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1002ms
rtt min/avg/max/mdev = 1.185/1.465/1.746/0.280 ms
```

**Docker app (root, gid 0):**
```
~ # grep NoNewPrivs /proc/self/status; cat /proc/sys/net/ipv4/ping_group_range; id; ping -c 2 8.8.8.8
NoNewPrivs:    1
1    65535
uid=0(root) gid=0(root) groups=1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),20(dialout),26(tape),27(video),0(root)
PING 8.8.8.8 (8.8.8.8): 56 data bytes
64 bytes from 8.8.8.8: seq=0 ttl=111 time=2.046 ms
64 bytes from 8.8.8.8: seq=1 ttl=111 time=1.233 ms

--- 8.8.8.8 ping statistics ---
2 packets transmitted, 2 packets received, 0% packet loss
round-trip min/avg/max = 1.233/1.639/2.046 ms
```


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
