### PR TITLE
Add NEWCGROUP to privileged container namespaces

### DIFF
--- a/guardiancmd/server.go
+++ b/guardiancmd/server.go
@@ -91,7 +91,7 @@ var privilegedMaxCaps = []string{
 var nonRootMaxCaps = append(unprivilegedMaxCaps, "CAP_SYS_ADMIN")
 
 var PrivilegedContainerNamespaces = []specs.LinuxNamespace{
-	goci.NetworkNamespace, goci.PIDNamespace, goci.UTSNamespace, goci.IPCNamespace, goci.MountNamespace,
+	goci.NetworkNamespace, goci.PIDNamespace, goci.UTSNamespace, goci.IPCNamespace, goci.MountNamespace, goci.CgroupNamespace,
 }
 
 var (


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Without a cgroup namespace, Garden containers share the host's cgroup tree. On cgroup v2, this causes BPM's runc to fail with "container's cgroup is not empty" when a deployed job has the same name as a job running on the host.

We encounter this issue on our BOSH Lite validation. The director host runs a "uaa" job. When the "uaa" instance of our "cf" test deployment is created, the "uaa" job cannot start:
```
time="2026-04-29T08:39:07Z" level=error msg="runc run failed: container's cgroup is not empty: 3 process(es) found"
```
Adding NEWCGROUP to the list of namespaces *should* resolve this issue. As of now, we don't have a running BOSH Lite setup with this patch, so we cannnot verify the proposed solution.

Backward Compatibility
---------------
I can't judge if this change has undesired side-effects or regressions.