### PR TITLE
fix: enable cgroupv2 subtree controllers before pea creation

### DIFF
--- a/guardiancmd/command.go
+++ b/guardiancmd/command.go
@@ -675,6 +675,12 @@ func (cmd *CommonCommand) wireContainerizer(
 		BundleSaver:      bundleSaver,
 		ExecRunner:       peasExecRunner,
 		PeaCleaner:       peaCleaner,
+		EnableControllersForCgroupsv2: func(cgroupPath string) error {
+			if !gardencgroups.IsCgroup2UnifiedMode() {
+				return nil
+			}
+			return gardencgroups.EnableSupportedControllers(cgroupPath)
+		},
 	}
 
 	peaUsernameResolver := &peas.PeaUsernameResolver{

--- a/rundmc/cgroups/cpucgrouper_linux.go
+++ b/rundmc/cgroups/cpucgrouper_linux.go
@@ -26,7 +26,7 @@ func (c CPUCgrouper) PrepareCgroups(handle string) error {
 		return err
 	}
 	if cgroups.IsCgroup2UnifiedMode() {
-		if err := enableSupportedControllers(badCgroupPath); err != nil {
+		if err := EnableSupportedControllers(badCgroupPath); err != nil {
 			return err
 		}
 	}

--- a/rundmc/cgroups/starter_linux.go
+++ b/rundmc/cgroups/starter_linux.go
@@ -219,7 +219,7 @@ func (s *CgroupStarter) createAndChownCgroupV2(logger lager.Logger) error {
 	if err := s.createChownedCgroup(logger, gardenCgroupPath); err != nil {
 		return err
 	}
-	if err := enableSupportedControllers(gardenCgroupPath); err != nil {
+	if err := EnableSupportedControllers(gardenCgroupPath); err != nil {
 		return err
 	}
 
@@ -228,7 +228,7 @@ func (s *CgroupStarter) createAndChownCgroupV2(logger lager.Logger) error {
 		if err := s.createChownedCgroup(logger, goodCgroupPath); err != nil {
 			return err
 		}
-		if err := enableSupportedControllers(goodCgroupPath); err != nil {
+		if err := EnableSupportedControllers(goodCgroupPath); err != nil {
 			return err
 		}
 
@@ -236,7 +236,7 @@ func (s *CgroupStarter) createAndChownCgroupV2(logger lager.Logger) error {
 		if err := s.createChownedCgroup(logger, badCgroupPath); err != nil {
 			return err
 		}
-		if err := enableSupportedControllers(badCgroupPath); err != nil {
+		if err := EnableSupportedControllers(badCgroupPath); err != nil {
 			return err
 		}
 	}
@@ -253,7 +253,7 @@ func (s *CgroupStarter) createChownedCgroup(logger lager.Logger, cgroupPath stri
 }
 
 // from fs2.CreateCgroupPath
-func enableSupportedControllers(cgroupPath string) error {
+func EnableSupportedControllers(cgroupPath string) error {
 	const (
 		cgStCtlFile = "cgroup.subtree_control"
 	)

--- a/rundmc/peas/pea_creator.go
+++ b/rundmc/peas/pea_creator.go
@@ -11,6 +11,7 @@ import (
 	"code.cloudfoundry.org/garden"
 	"code.cloudfoundry.org/guardian/gardener"
 	spec "code.cloudfoundry.org/guardian/gardener/container-spec"
+	"code.cloudfoundry.org/guardian/rundmc/cgroups"
 	"code.cloudfoundry.org/guardian/rundmc/depot"
 	"code.cloudfoundry.org/guardian/rundmc/goci"
 	"code.cloudfoundry.org/guardian/rundmc/runrunc"
@@ -68,6 +69,10 @@ type PeaCreator struct {
 	ProcessBuilder   runrunc.ProcessBuilder
 	ExecRunner       ExecRunner
 	PeaCleaner       gardener.PeaCleaner
+	// EnableControllersForCgroupsv2 enables cgroup subtree controllers on the
+	// sandbox cgroup path before the pea sub-cgroup is created. Nil on cgroupv1
+	// hosts (Jammy).
+	EnableControllersForCgroupsv2 func(cgroupPath string) error
 }
 
 func (p *PeaCreator) CreatePea(log lager.Logger, processSpec garden.ProcessSpec, procIO garden.ProcessIO, sandboxHandle string) (_ garden.Process, theErr error) {
@@ -154,6 +159,13 @@ func (p *PeaCreator) CreatePea(log lager.Logger, processSpec garden.ProcessSpec,
 
 	preparedProcess := p.ProcessBuilder.BuildProcess(bndl, processSpec, &users.ExecUser{Uid: userUID, Gid: userGID})
 	bndl = bndl.WithProcess(*preparedProcess)
+
+	if p.EnableControllersForCgroupsv2 != nil {
+		sandboxCgroupPath := filepath.Join(cgroups.Root, cgroups.Garden, sandboxHandle)
+		if err := p.EnableControllersForCgroupsv2(sandboxCgroupPath); err != nil {
+			log.Error("enable-sandbox-cgroup-controllers-failed", err)
+		}
+	}
 
 	extraCleanup := func() error {
 		return p.PeaCleaner.Clean(log, processID)

--- a/rundmc/peas/pea_creator_test.go
+++ b/rundmc/peas/pea_creator_test.go
@@ -8,6 +8,7 @@ import (
 
 	"code.cloudfoundry.org/garden"
 	"code.cloudfoundry.org/guardian/gardener/gardenerfakes"
+	"code.cloudfoundry.org/guardian/rundmc/cgroups"
 	"code.cloudfoundry.org/guardian/rundmc/depot/depotfakes"
 	"code.cloudfoundry.org/guardian/rundmc/goci"
 	"code.cloudfoundry.org/guardian/rundmc/peas"
@@ -35,9 +36,11 @@ var _ = Describe("PeaCreator", func() {
 
 		peaCreator *peas.PeaCreator
 
-		ctrHandle    string
-		ctrBundleDir string
-		log          *lagertest.TestLogger
+		ctrHandle                string
+		ctrBundleDir             string
+		log                      *lagertest.TestLogger
+		cgroupV2EnablerCallCount int
+		capturedCgroupPath       string
 
 		generatedBundle   = goci.Bndl{Spec: specs.Spec{Version: "our-bundle"}}
 		defaultBindMounts = []garden.BindMount{{
@@ -90,6 +93,14 @@ var _ = Describe("PeaCreator", func() {
 			ExecRunner:       execRunner,
 			PrivilegedGetter: privilegedGetter,
 			PeaCleaner:       peaCleaner,
+		}
+
+		cgroupV2EnablerCallCount = 0
+		capturedCgroupPath = ""
+		peaCreator.EnableControllersForCgroupsv2 = func(cgroupPath string) error {
+			cgroupV2EnablerCallCount++
+			capturedCgroupPath = cgroupPath
+			return nil
 		}
 
 		var err error
@@ -316,6 +327,25 @@ var _ = Describe("PeaCreator", func() {
 					CPU:    processSpec.OverrideContainerLimits.CPU,
 					Memory: processSpec.OverrideContainerLimits.Memory,
 				}))
+			})
+		})
+
+		Context("when CgroupV2Enabler is set (cgroupv2 path)", func() {
+			It("calls CgroupV2Enabler with the sandbox cgroup path before running the pea", func() {
+				Expect(cgroupV2EnablerCallCount).To(Equal(1))
+				expectedPath := filepath.Join(cgroups.Root, cgroups.Garden, ctrHandle)
+				Expect(capturedCgroupPath).To(Equal(expectedPath))
+			})
+		})
+
+		Context("when EnableControllersForCgroupsv2 is nil (cgroupv1 / Jammy path)", func() {
+			BeforeEach(func() {
+				peaCreator.EnableControllersForCgroupsv2 = nil
+			})
+
+			It("creates the pea without error", func() {
+				_, err := peaCreator.CreatePea(log, processSpec, pio, ctrHandle)
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 	})


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

On Ubuntu Noble (cgroupv2), runc stats for a pea return zero memory fields because the memory controller is not enabled in the parent container cgroup.subtree_control. Add EnableControllersForCgroupsv2 to PeaCreator which writes +memory (and all available controllers) to the sandbox cgroup subtree_control before RunPea, mirroring the existing fix in the containerd path. The IsCgroup2UnifiedMode guard in command.go ensures the call is a no-op on Jammy (cgroupv1).

Backward Compatibility
---------------
Breaking Change? No