### PR TITLE
feat: export EnableSupportedControllers and move Root/Garden to const…

### DIFF
--- a/rundmc/cgroups/constants.go
+++ b/rundmc/cgroups/constants.go
@@ -1,6 +1,8 @@
 package cgroups
 
 const (
+	Root           = "/sys/fs/cgroup"
+	Garden         = "garden"
 	GoodCgroupName = "good"
 	BadCgroupName  = "bad"
 	InitCgroupName = "init"

--- a/rundmc/cgroups/starter_linux.go
+++ b/rundmc/cgroups/starter_linux.go
@@ -21,8 +21,6 @@ import (
 )
 
 const (
-	Root   = "/sys/fs/cgroup"
-	Garden = "garden"
 	Header = "#subsys_name hierarchy num_cgroups enabled"
 )
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
…ants.go

Rename enableSupportedControllers to EnableSupportedControllers so pea_creator can call it from outside the cgroups package. Move Root and Garden constants from starter_linux.go to constants.go so they are available in pea_creator.go without a build tag. The string values are harmless on non-Linux platforms where pea creation is never invoked.

Backward Compatibility
---------------
Breaking Change? No
