### PR TITLE
fix(peas): propagate memory.swap.max=0 to sandbox cgroup on cgroupsv2

### DIFF
--- a/guardiancmd/command.go
+++ b/guardiancmd/command.go
@@ -1,3 +1,8 @@
+// @AI-Generated
+// Generated in whole or in part by Cursor with a mix of different LLM models (Auto select mode)
+// Description:
+// 2026-06-11: Wire UseInitSubCgroup=true on cgroupsv2 to put container init in sandbox-id/init sub-cgroup
+
 package guardiancmd
 
 import (
@@ -568,7 +573,8 @@ func (cmd *CommonCommand) wireContainerizer(
 		},
 		bundlerules.Namespaces{},
 		bundlerules.CGroupPath{
-			Path: cgroupRootPath,
+			Path:             cgroupRootPath,
+			UseInitSubCgroup: gardencgroups.IsCgroup2UnifiedMode(),
 		},
 		wireMounts(log),
 		bundlerules.Env{},
@@ -682,12 +688,6 @@ func (cmd *CommonCommand) wireContainerizer(
 		BundleSaver:      bundleSaver,
 		ExecRunner:       peasExecRunner,
 		PeaCleaner:       peaCleaner,
-		EnableControllersForCgroupsv2: func(cgroupPath string) error {
-			if !gardencgroups.IsCgroup2UnifiedMode() {
-				return nil
-			}
-			return gardencgroups.EnableSupportedControllers(cgroupPath)
-		},
 	}
 
 	peaUsernameResolver := &peas.PeaUsernameResolver{

--- a/rundmc/bundlerules/cgroup_path.go
+++ b/rundmc/bundlerules/cgroup_path.go
@@ -1,3 +1,8 @@
+// @AI-Generated
+// Generated in whole or in part by Cursor with a mix of different LLM models (Auto select mode)
+// Description:
+// 2026-06-11: Use sandbox-id/init sub-cgroup for container init process on cgroupsv2 to allow PEA memory tracking
+
 package bundlerules
 
 import (
@@ -7,8 +12,22 @@ import (
 	"code.cloudfoundry.org/guardian/rundmc/goci"
 )
 
+// ContainerInitSubCgroup is the sub-cgroup name used on cgroupsv2 to house the
+// container's init process. Using a sub-cgroup keeps the parent (sandbox-id)
+// free of direct processes, which allows domain controllers such as memory to
+// remain in its cgroup.subtree_control. PEA sub-cgroups created alongside the
+// init sub-cgroup then inherit memory accounting.
+const ContainerInitSubCgroup = "init"
+
 type CGroupPath struct {
 	Path string
+	// UseInitSubCgroup should be set to true on cgroupsv2 hosts. When true the
+	// container init process is placed in a "init" sub-cgroup of the sandbox
+	// cgroup so that the parent cgroup (sandbox-id) remains free of direct
+	// processes. This is required for domain controllers (e.g. memory) to be
+	// kept in the parent's cgroup.subtree_control, which in turn enables memory
+	// accounting for PEA sub-cgroups.
+	UseInitSubCgroup bool
 }
 
 func (r CGroupPath) Apply(bndl goci.Bndl, spec spec.DesiredContainerSpec) (goci.Bndl, error) {
@@ -16,9 +35,16 @@ func (r CGroupPath) Apply(bndl goci.Bndl, spec spec.DesiredContainerSpec) (goci.
 		return bndl, nil
 	}
 
+	var basePath string
 	if spec.CgroupPath != "" {
-		return bndl.WithCGroupPath(filepath.Join(r.Path, spec.CgroupPath)), nil
+		basePath = filepath.Join(r.Path, spec.CgroupPath)
+	} else {
+		basePath = filepath.Join(r.Path, spec.Handle)
 	}
 
-	return bndl.WithCGroupPath(filepath.Join(r.Path, spec.Handle)), nil
+	if r.UseInitSubCgroup {
+		return bndl.WithCGroupPath(filepath.Join(basePath, ContainerInitSubCgroup)), nil
+	}
+
+	return bndl.WithCGroupPath(basePath), nil
 }

--- a/rundmc/cgroups/cpucgrouper_linux.go
+++ b/rundmc/cgroups/cpucgrouper_linux.go
@@ -1,6 +1,14 @@
+// @AI-Generated
+// Generated in whole or in part by Cursor with a mix of different LLM models (Auto select mode)
+// Description:
+// 2026-06-11: Add PropagateContainerMemoryLimit for cgroupsv2 PEA memory limit inheritance (CPU throttling path)
+// 2026-06-11: Also propagate memory.swap.max=0 so PEAs cannot bypass the limit via swap
+
 package cgroups
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -39,6 +47,32 @@ func (c CPUCgrouper) CleanupCgroups(handle string) error {
 	}
 	if err := os.RemoveAll(filepath.Join(c.cgroupRoot, GoodCgroupName, handle)); err != nil {
 		return err
+	}
+	return nil
+}
+
+// PropagateContainerMemoryLimit writes the container memory limit to the
+// good-cgroup sandbox path so PEAs (siblings of the container's init
+// sub-cgroup) inherit the same memory constraint on cgroupsv2.
+// When disableSwapLimit is false, memory.swap.max is also set to 0 so
+// that PEAs cannot bypass the memory limit by swapping.
+func (c CPUCgrouper) PropagateContainerMemoryLimit(handle string, memoryLimit int64, disableSwapLimit bool) error {
+	if !cgroups.IsCgroup2UnifiedMode() || memoryLimit <= 0 {
+		return nil
+	}
+	sandboxCgroupPath := filepath.Join(c.cgroupRoot, GoodCgroupName, handle)
+	if err := os.WriteFile(
+		filepath.Join(sandboxCgroupPath, "memory.max"),
+		[]byte(fmt.Sprintf("%d", memoryLimit)),
+		0644,
+	); err != nil {
+		return err
+	}
+	if !disableSwapLimit {
+		err := os.WriteFile(filepath.Join(sandboxCgroupPath, "memory.swap.max"), []byte("0"), 0644)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
 	}
 	return nil
 }

--- a/rundmc/cgroups/defaultcgrouper_linux.go
+++ b/rundmc/cgroups/defaultcgrouper_linux.go
@@ -1,0 +1,42 @@
+// @AI-Generated
+// Generated in whole or in part by Cursor with a mix of different LLM models (Auto select mode)
+// Description:
+// 2026-06-11: Propagate container memory limit to sandbox cgroup for PEA inheritance on cgroupsv2
+// 2026-06-11: Also propagate memory.swap.max=0 so PEAs cannot bypass the limit via swap
+
+package cgroups
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// PropagateContainerMemoryLimit writes the container memory limit to the sandbox
+// cgroup so that PEAs (which are siblings of the container's init sub-cgroup)
+// inherit the same memory constraint via the parent cgroup hierarchy.
+// This is only needed on cgroupsv2 where the container init process lives at
+// sandbox/init, leaving sandbox itself with no explicit memory.max.
+// When disableSwapLimit is false, memory.swap.max is also set to 0 so that
+// PEAs cannot bypass the memory limit by swapping.
+func (c DefaultCgrouper) PropagateContainerMemoryLimit(handle string, memoryLimit int64, disableSwapLimit bool) error {
+	if !IsCgroup2UnifiedMode() || memoryLimit <= 0 {
+		return nil
+	}
+	sandboxCgroupPath := filepath.Join(c.cgroupRoot, handle)
+	if err := os.WriteFile(
+		filepath.Join(sandboxCgroupPath, "memory.max"),
+		[]byte(fmt.Sprintf("%d", memoryLimit)),
+		0644,
+	); err != nil {
+		return err
+	}
+	if !disableSwapLimit {
+		err := os.WriteFile(filepath.Join(sandboxCgroupPath, "memory.swap.max"), []byte("0"), 0644)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return nil
+}

--- a/rundmc/cgroups/defaultcgrouper_notlinux.go
+++ b/rundmc/cgroups/defaultcgrouper_notlinux.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package cgroups
+
+func (DefaultCgrouper) PropagateContainerMemoryLimit(_ string, _ int64, _ bool) error {
+	return nil
+}

--- a/rundmc/containerizer.go
+++ b/rundmc/containerizer.go
@@ -1,3 +1,8 @@
+// @AI-Generated
+// Generated in whole or in part by Cursor with a mix of different LLM models (Auto select mode)
+// Description:
+// 2026-06-11: Add PropagateContainerMemoryLimit to CPUCgrouper interface and call after container creation
+
 package rundmc
 
 import (
@@ -100,6 +105,7 @@ type CPUCgrouper interface {
 	PrepareCgroups(handle string) error
 	CleanupCgroups(handle string) error
 	ReadTotalCgroupUsage(handle string, cpuStats garden.ContainerCPUStat) (garden.ContainerCPUStat, error)
+	PropagateContainerMemoryLimit(handle string, memoryLimit int64, disableSwapLimit bool) error
 }
 
 // Containerizer knows how to manage a depot of container bundles
@@ -186,6 +192,16 @@ func (c *Containerizer) Create(log lager.Logger, spec spec.DesiredContainerSpec)
 
 	if err := c.runtime.Create(log, spec.Handle, bundle, garden.ProcessIO{}); err != nil {
 		log.Error("runtime-create-failed", err)
+		return err
+	}
+
+	// Determine if swap is being limited by checking whether the bundle's memory
+	// swap field was set (i.e. DisableSwapLimit was false in the bundler config).
+	disableSwapLimit := bundle.Spec.Linux == nil ||
+		bundle.Spec.Linux.Resources == nil ||
+		bundle.Spec.Linux.Resources.Memory.Swap == nil
+	if err := c.cpuCgrouper.PropagateContainerMemoryLimit(spec.Handle, int64(spec.Limits.Memory.LimitInBytes), disableSwapLimit); err != nil {
+		log.Error("propagate-memory-limit-failed", err)
 		return err
 	}
 

--- a/rundmc/peas/pea_creator.go
+++ b/rundmc/peas/pea_creator.go
@@ -11,7 +11,6 @@ import (
 	"code.cloudfoundry.org/garden"
 	"code.cloudfoundry.org/guardian/gardener"
 	spec "code.cloudfoundry.org/guardian/gardener/container-spec"
-	"code.cloudfoundry.org/guardian/rundmc/cgroups"
 	"code.cloudfoundry.org/guardian/rundmc/depot"
 	"code.cloudfoundry.org/guardian/rundmc/goci"
 	"code.cloudfoundry.org/guardian/rundmc/runrunc"
@@ -69,10 +68,6 @@ type PeaCreator struct {
 	ProcessBuilder   runrunc.ProcessBuilder
 	ExecRunner       ExecRunner
 	PeaCleaner       gardener.PeaCleaner
-	// EnableControllersForCgroupsv2 enables cgroup subtree controllers on the
-	// sandbox cgroup path before the pea sub-cgroup is created. Nil on cgroupv1
-	// hosts (Jammy).
-	EnableControllersForCgroupsv2 func(cgroupPath string) error
 }
 
 func (p *PeaCreator) CreatePea(log lager.Logger, processSpec garden.ProcessSpec, procIO garden.ProcessIO, sandboxHandle string) (_ garden.Process, theErr error) {
@@ -159,13 +154,6 @@ func (p *PeaCreator) CreatePea(log lager.Logger, processSpec garden.ProcessSpec,
 
 	preparedProcess := p.ProcessBuilder.BuildProcess(bndl, processSpec, &users.ExecUser{Uid: userUID, Gid: userGID})
 	bndl = bndl.WithProcess(*preparedProcess)
-
-	if p.EnableControllersForCgroupsv2 != nil {
-		sandboxCgroupPath := filepath.Join(cgroups.Root, cgroups.Garden, sandboxHandle)
-		if err := p.EnableControllersForCgroupsv2(sandboxCgroupPath); err != nil {
-			log.Error("enable-sandbox-cgroup-controllers-failed", err)
-		}
-	}
 
 	extraCleanup := func() error {
 		return p.PeaCleaner.Clean(log, processID)

--- a/rundmc/peas/pea_creator_test.go
+++ b/rundmc/peas/pea_creator_test.go
@@ -8,7 +8,6 @@ import (
 
 	"code.cloudfoundry.org/garden"
 	"code.cloudfoundry.org/guardian/gardener/gardenerfakes"
-	"code.cloudfoundry.org/guardian/rundmc/cgroups"
 	"code.cloudfoundry.org/guardian/rundmc/depot/depotfakes"
 	"code.cloudfoundry.org/guardian/rundmc/goci"
 	"code.cloudfoundry.org/guardian/rundmc/peas"
@@ -36,12 +35,9 @@ var _ = Describe("PeaCreator", func() {
 
 		peaCreator *peas.PeaCreator
 
-		ctrHandle                string
-		ctrBundleDir             string
-		log                      *lagertest.TestLogger
-		cgroupV2EnablerCallCount int
-		capturedCgroupPath       string
-
+		ctrHandle         string
+		ctrBundleDir      string
+		log               *lagertest.TestLogger
 		generatedBundle   = goci.Bndl{Spec: specs.Spec{Version: "our-bundle"}}
 		defaultBindMounts = []garden.BindMount{{
 			SrcPath: "/some/src",
@@ -93,14 +89,6 @@ var _ = Describe("PeaCreator", func() {
 			ExecRunner:       execRunner,
 			PrivilegedGetter: privilegedGetter,
 			PeaCleaner:       peaCleaner,
-		}
-
-		cgroupV2EnablerCallCount = 0
-		capturedCgroupPath = ""
-		peaCreator.EnableControllersForCgroupsv2 = func(cgroupPath string) error {
-			cgroupV2EnablerCallCount++
-			capturedCgroupPath = cgroupPath
-			return nil
 		}
 
 		var err error
@@ -330,24 +318,6 @@ var _ = Describe("PeaCreator", func() {
 			})
 		})
 
-		Context("when CgroupV2Enabler is set (cgroupv2 path)", func() {
-			It("calls CgroupV2Enabler with the sandbox cgroup path before running the pea", func() {
-				Expect(cgroupV2EnablerCallCount).To(Equal(1))
-				expectedPath := filepath.Join(cgroups.Root, cgroups.Garden, ctrHandle)
-				Expect(capturedCgroupPath).To(Equal(expectedPath))
-			})
-		})
-
-		Context("when EnableControllersForCgroupsv2 is nil (cgroupv1 / Jammy path)", func() {
-			BeforeEach(func() {
-				peaCreator.EnableControllersForCgroupsv2 = nil
-			})
-
-			It("creates the pea without error", func() {
-				_, err := peaCreator.CreatePea(log, processSpec, pio, ctrHandle)
-				Expect(err).NotTo(HaveOccurred())
-			})
-		})
 	})
 
 	Describe("pea creation failing", func() {

--- a/rundmc/rundmcfakes/fake_cpucgrouper.go
+++ b/rundmc/rundmcfakes/fake_cpucgrouper.go
@@ -31,6 +31,19 @@ type FakeCPUCgrouper struct {
 	prepareCgroupsReturnsOnCall map[int]struct {
 		result1 error
 	}
+	PropagateContainerMemoryLimitStub        func(string, int64, bool) error
+	propagateContainerMemoryLimitMutex       sync.RWMutex
+	propagateContainerMemoryLimitArgsForCall []struct {
+		arg1 string
+		arg2 int64
+		arg3 bool
+	}
+	propagateContainerMemoryLimitReturns struct {
+		result1 error
+	}
+	propagateContainerMemoryLimitReturnsOnCall map[int]struct {
+		result1 error
+	}
 	ReadTotalCgroupUsageStub        func(string, garden.ContainerCPUStat) (garden.ContainerCPUStat, error)
 	readTotalCgroupUsageMutex       sync.RWMutex
 	readTotalCgroupUsageArgsForCall []struct {
@@ -171,6 +184,69 @@ func (fake *FakeCPUCgrouper) PrepareCgroupsReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeCPUCgrouper) PropagateContainerMemoryLimit(arg1 string, arg2 int64, arg3 bool) error {
+	fake.propagateContainerMemoryLimitMutex.Lock()
+	ret, specificReturn := fake.propagateContainerMemoryLimitReturnsOnCall[len(fake.propagateContainerMemoryLimitArgsForCall)]
+	fake.propagateContainerMemoryLimitArgsForCall = append(fake.propagateContainerMemoryLimitArgsForCall, struct {
+		arg1 string
+		arg2 int64
+		arg3 bool
+	}{arg1, arg2, arg3})
+	stub := fake.PropagateContainerMemoryLimitStub
+	fakeReturns := fake.propagateContainerMemoryLimitReturns
+	fake.recordInvocation("PropagateContainerMemoryLimit", []interface{}{arg1, arg2, arg3})
+	fake.propagateContainerMemoryLimitMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeCPUCgrouper) PropagateContainerMemoryLimitCallCount() int {
+	fake.propagateContainerMemoryLimitMutex.RLock()
+	defer fake.propagateContainerMemoryLimitMutex.RUnlock()
+	return len(fake.propagateContainerMemoryLimitArgsForCall)
+}
+
+func (fake *FakeCPUCgrouper) PropagateContainerMemoryLimitCalls(stub func(string, int64, bool) error) {
+	fake.propagateContainerMemoryLimitMutex.Lock()
+	defer fake.propagateContainerMemoryLimitMutex.Unlock()
+	fake.PropagateContainerMemoryLimitStub = stub
+}
+
+func (fake *FakeCPUCgrouper) PropagateContainerMemoryLimitArgsForCall(i int) (string, int64, bool) {
+	fake.propagateContainerMemoryLimitMutex.RLock()
+	defer fake.propagateContainerMemoryLimitMutex.RUnlock()
+	argsForCall := fake.propagateContainerMemoryLimitArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeCPUCgrouper) PropagateContainerMemoryLimitReturns(result1 error) {
+	fake.propagateContainerMemoryLimitMutex.Lock()
+	defer fake.propagateContainerMemoryLimitMutex.Unlock()
+	fake.PropagateContainerMemoryLimitStub = nil
+	fake.propagateContainerMemoryLimitReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeCPUCgrouper) PropagateContainerMemoryLimitReturnsOnCall(i int, result1 error) {
+	fake.propagateContainerMemoryLimitMutex.Lock()
+	defer fake.propagateContainerMemoryLimitMutex.Unlock()
+	fake.PropagateContainerMemoryLimitStub = nil
+	if fake.propagateContainerMemoryLimitReturnsOnCall == nil {
+		fake.propagateContainerMemoryLimitReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.propagateContainerMemoryLimitReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeCPUCgrouper) ReadTotalCgroupUsage(arg1 string, arg2 garden.ContainerCPUStat) (garden.ContainerCPUStat, error) {
 	fake.readTotalCgroupUsageMutex.Lock()
 	ret, specificReturn := fake.readTotalCgroupUsageReturnsOnCall[len(fake.readTotalCgroupUsageArgsForCall)]
@@ -243,6 +319,8 @@ func (fake *FakeCPUCgrouper) Invocations() map[string][][]interface{} {
 	defer fake.cleanupCgroupsMutex.RUnlock()
 	fake.prepareCgroupsMutex.RLock()
 	defer fake.prepareCgroupsMutex.RUnlock()
+	fake.propagateContainerMemoryLimitMutex.RLock()
+	defer fake.propagateContainerMemoryLimitMutex.RUnlock()
 	fake.readTotalCgroupUsageMutex.RLock()
 	defer fake.readTotalCgroupUsageMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}


### PR DESCRIPTION


- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
PEAs inherit memory limits from the parent sandbox cgroup. On cgroupsv2, runc sets memory.swap.max=0 on the init sub-cgroup but the sandbox cgroup had no swap limit, so PEAs could bypass the RAM limit via swap when the host has swap enabled. Propagate memory.swap.max=0 to the sandbox cgroup in PropagateContainerMemoryLimit, mirroring runc, but only when DisableSwapLimit is false. Split implementation into _linux.go to keep IsCgroup2UnifiedMode out of cross-platform files (go vet clean).

ai-assisted=yes
TNZ-92428

Backward Compatibility
---------------
Breaking Change? NO
