### PR TITLE
Add per-container io.max throttling support (cgroups v2)

### DIFF
--- a/gardener/gardener_test.go
+++ b/gardener/gardener_test.go
@@ -1877,6 +1877,7 @@ var _ = Describe("Gardener", func() {
 			containerizer.InfoReturns(spec.ActualContainerSpec{
 				Limits: garden.Limits{
 					CPU: garden.CPULimits{
+						//lint:ignore SA1019 - we still specify this to make the deprecated logic work until we get rid of the code in garden
 						LimitInShares: 10,
 					},
 				},

--- a/gqt/create_linux_test.go
+++ b/gqt/create_linux_test.go
@@ -417,7 +417,8 @@ var _ = Describe("Creating a Container", func() {
 		createContainerWithCpuConfig := func(weight, shares uint64) (garden.Container, error) {
 			limits := garden.Limits{
 				CPU: garden.CPULimits{
-					Weight:        weight,
+					Weight: weight,
+					//lint:ignore SA1019 - we still specify this to make the deprecated logic work until we get rid of the code in garden
 					LimitInShares: shares,
 				},
 			}

--- a/gqt/limits_test.go
+++ b/gqt/limits_test.go
@@ -108,6 +108,7 @@ var _ = Describe("Limits", func() {
 
 		Context("CPU Limits", func() {
 			BeforeEach(func() {
+				//lint:ignore SA1019 - we still specify this to make the deprecated logic work until we get rid of the code in garden
 				limits = garden.Limits{CPU: garden.CPULimits{LimitInShares: 128}}
 				cgroupType = "cpu"
 			})

--- a/gqt/peas_linux_test.go
+++ b/gqt/peas_linux_test.go
@@ -201,6 +201,7 @@ var _ = Describe("Partially shared containers (peas)", func() {
 						Args:  []string{"-c", "cat /proc/self/cgroup && echo done && sleep 3600"},
 						Image: garden.ImageRef{URI: "raw://" + peaRootfs},
 						OverrideContainerLimits: &garden.ProcessLimits{
+							//lint:ignore SA1019 - we still specify this to make the deprecated logic work until we get rid of the code in garden
 							CPU: garden.CPULimits{LimitInShares: 128},
 						},
 					}, garden.ProcessIO{
@@ -266,6 +267,7 @@ var _ = Describe("Partially shared containers (peas)", func() {
 						Args:  []string{"-c", "cat /proc/self/cgroup && echo done && sleep 3600"},
 						Image: garden.ImageRef{URI: "raw://" + peaRootfs},
 						OverrideContainerLimits: &garden.ProcessLimits{
+							//lint:ignore SA1019 - we still specify this to make the deprecated logic work until we get rid of the code in garden
 							CPU: garden.CPULimits{LimitInShares: 128},
 						},
 					}, garden.ProcessIO{

--- a/gqt/runtime_plugin_test.go
+++ b/gqt/runtime_plugin_test.go
@@ -85,6 +85,7 @@ var _ = Describe("Runtime Plugin", func() {
 							LimitInBytes: 1 * 1024 * 1024,
 						},
 						CPU: garden.CPULimits{
+							//lint:ignore SA1019 - we still specify this to make the deprecated logic work until we get rid of the code in garden
 							LimitInShares: 10,
 						},
 						Pid: garden.PidLimits{

--- a/guardiancmd/command.go
+++ b/guardiancmd/command.go
@@ -175,10 +175,14 @@ type CommonCommand struct {
 	} `group:"Container Networking"`
 
 	Limits struct {
-		CPUQuotaPerShare     uint64 `long:"cpu-quota-per-share" default:"0" description:"Maximum number of microseconds each cpu share assigned to a container allows per quota period"`
-		DefaultBlockIOWeight uint16 `long:"default-container-blockio-weight" default:"0" description:"Default block IO weight assigned to a container"`
-		MaxContainers        uint64 `long:"max-containers" default:"0" description:"Maximum number of containers that can be created."`
-		DisableSwapLimit     bool   `long:"disable-swap-limit" description:"Disable swap memory limit"`
+		CPUQuotaPerShare          uint64 `long:"cpu-quota-per-share" default:"0" description:"Maximum number of microseconds each cpu share assigned to a container allows per quota period"`
+		DefaultBlockIOWeight      uint16 `long:"default-container-blockio-weight" default:"0" description:"Default block IO weight assigned to a container"`
+		ContainerIOMaxReadBps     uint64 `long:"container-io-max-read-bps" default:"0" description:"Per-container read bytes/s limit (cgroups v2 only, 0=unlimited)"`
+		ContainerIOMaxWriteBps    uint64 `long:"container-io-max-write-bps" default:"0" description:"Per-container write bytes/s limit (cgroups v2 only, 0=unlimited)"`
+		ContainerIOMaxReadIOPS    uint64 `long:"container-io-max-read-iops" default:"0" description:"Per-container read IOPS limit (cgroups v2 only, 0=unlimited)"`
+		ContainerIOMaxWriteIOPS   uint64 `long:"container-io-max-write-iops" default:"0" description:"Per-container write IOPS limit (cgroups v2 only, 0=unlimited)"`
+		MaxContainers             uint64 `long:"max-containers" default:"0" description:"Maximum number of containers that can be created."`
+		DisableSwapLimit          bool   `long:"disable-swap-limit" description:"Disable swap memory limit"`
 	} `group:"Limits"`
 
 	Metrics struct {
@@ -576,9 +580,13 @@ func (cmd *CommonCommand) wireContainerizer(
 		bundlerules.Windows{},
 		bundlerules.RootFS{},
 		bundlerules.Limits{
-			CpuQuotaPerShare: cmd.Limits.CPUQuotaPerShare,
-			BlockIOWeight:    cmd.Limits.DefaultBlockIOWeight,
-			DisableSwapLimit: cmd.Limits.DisableSwapLimit,
+			CpuQuotaPerShare:     cmd.Limits.CPUQuotaPerShare,
+			BlockIOWeight:        cmd.Limits.DefaultBlockIOWeight,
+			IOMaxReadBps:         cmd.Limits.ContainerIOMaxReadBps,
+			IOMaxWriteBps:        cmd.Limits.ContainerIOMaxWriteBps,
+			IOMaxReadIOPS:        cmd.Limits.ContainerIOMaxReadIOPS,
+			IOMaxWriteIOPS:       cmd.Limits.ContainerIOMaxWriteIOPS,
+			DisableSwapLimit:     cmd.Limits.DisableSwapLimit,
 		},
 	}
 

--- a/guardiancmd/command.go
+++ b/guardiancmd/command.go
@@ -175,14 +175,14 @@ type CommonCommand struct {
 	} `group:"Container Networking"`
 
 	Limits struct {
-		CPUQuotaPerShare          uint64 `long:"cpu-quota-per-share" default:"0" description:"Maximum number of microseconds each cpu share assigned to a container allows per quota period"`
-		DefaultBlockIOWeight      uint16 `long:"default-container-blockio-weight" default:"0" description:"Default block IO weight assigned to a container"`
-		ContainerIOMaxReadBps     uint64 `long:"container-io-max-read-bps" default:"0" description:"Per-container read bytes/s limit (cgroups v2 only, 0=unlimited)"`
-		ContainerIOMaxWriteBps    uint64 `long:"container-io-max-write-bps" default:"0" description:"Per-container write bytes/s limit (cgroups v2 only, 0=unlimited)"`
-		ContainerIOMaxReadIOPS    uint64 `long:"container-io-max-read-iops" default:"0" description:"Per-container read IOPS limit (cgroups v2 only, 0=unlimited)"`
-		ContainerIOMaxWriteIOPS   uint64 `long:"container-io-max-write-iops" default:"0" description:"Per-container write IOPS limit (cgroups v2 only, 0=unlimited)"`
-		MaxContainers             uint64 `long:"max-containers" default:"0" description:"Maximum number of containers that can be created."`
-		DisableSwapLimit          bool   `long:"disable-swap-limit" description:"Disable swap memory limit"`
+		CPUQuotaPerShare        uint64 `long:"cpu-quota-per-share" default:"0" description:"Maximum number of microseconds each cpu share assigned to a container allows per quota period"`
+		DefaultBlockIOWeight    uint16 `long:"default-container-blockio-weight" default:"0" description:"Default block IO weight assigned to a container"`
+		ContainerIOMaxReadBps   uint64 `long:"container-io-max-read-bps" default:"0" description:"Per-container read bytes/s limit (cgroups v2 only, 0=unlimited)"`
+		ContainerIOMaxWriteBps  uint64 `long:"container-io-max-write-bps" default:"0" description:"Per-container write bytes/s limit (cgroups v2 only, 0=unlimited)"`
+		ContainerIOMaxReadIOPS  uint64 `long:"container-io-max-read-iops" default:"0" description:"Per-container read IOPS limit (cgroups v2 only, 0=unlimited)"`
+		ContainerIOMaxWriteIOPS uint64 `long:"container-io-max-write-iops" default:"0" description:"Per-container write IOPS limit (cgroups v2 only, 0=unlimited)"`
+		MaxContainers           uint64 `long:"max-containers" default:"0" description:"Maximum number of containers that can be created."`
+		DisableSwapLimit        bool   `long:"disable-swap-limit" description:"Disable swap memory limit"`
 	} `group:"Limits"`
 
 	Metrics struct {
@@ -580,13 +580,13 @@ func (cmd *CommonCommand) wireContainerizer(
 		bundlerules.Windows{},
 		bundlerules.RootFS{},
 		bundlerules.Limits{
-			CpuQuotaPerShare:     cmd.Limits.CPUQuotaPerShare,
-			BlockIOWeight:        cmd.Limits.DefaultBlockIOWeight,
-			IOMaxReadBps:         cmd.Limits.ContainerIOMaxReadBps,
-			IOMaxWriteBps:        cmd.Limits.ContainerIOMaxWriteBps,
-			IOMaxReadIOPS:        cmd.Limits.ContainerIOMaxReadIOPS,
-			IOMaxWriteIOPS:       cmd.Limits.ContainerIOMaxWriteIOPS,
-			DisableSwapLimit:     cmd.Limits.DisableSwapLimit,
+			CpuQuotaPerShare: cmd.Limits.CPUQuotaPerShare,
+			BlockIOWeight:    cmd.Limits.DefaultBlockIOWeight,
+			IOMaxReadBps:     cmd.Limits.ContainerIOMaxReadBps,
+			IOMaxWriteBps:    cmd.Limits.ContainerIOMaxWriteBps,
+			IOMaxReadIOPS:    cmd.Limits.ContainerIOMaxReadIOPS,
+			IOMaxWriteIOPS:   cmd.Limits.ContainerIOMaxWriteIOPS,
+			DisableSwapLimit: cmd.Limits.DisableSwapLimit,
 		},
 	}
 

--- a/rundmc/bundlerules/limits.go
+++ b/rundmc/bundlerules/limits.go
@@ -2,8 +2,12 @@ package bundlerules
 
 import (
 	"math"
+	"os"
+	"strconv"
+	"strings"
 
 	spec "code.cloudfoundry.org/guardian/gardener/container-spec"
+	"code.cloudfoundry.org/guardian/rundmc/cgroups"
 	"code.cloudfoundry.org/guardian/rundmc/goci"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -16,6 +20,10 @@ var (
 type Limits struct {
 	CpuQuotaPerShare uint64
 	BlockIOWeight    uint16
+	IOMaxReadBps     uint64
+	IOMaxWriteBps    uint64
+	IOMaxReadIOPS    uint64
+	IOMaxWriteIOPS   uint64
 	DisableSwapLimit bool
 }
 
@@ -52,7 +60,33 @@ func (l Limits) Apply(bndl goci.Bndl, spec spec.DesiredContainerSpec) (goci.Bndl
 	}
 	bndl = bndl.WithCPUShares(cpuSpec)
 
-	bndl = bndl.WithBlockIO(specs.LinuxBlockIO{Weight: &l.BlockIOWeight})
+	blockIO := specs.LinuxBlockIO{Weight: &l.BlockIOWeight}
+
+	if cgroups.IsCgroup2UnifiedMode() && (l.IOMaxReadBps > 0 || l.IOMaxWriteBps > 0 || l.IOMaxReadIOPS > 0 || l.IOMaxWriteIOPS > 0) {
+		devices := getAllBlockDevices()
+
+		var readBps, writeBps, readIOPS, writeIOPS []specs.LinuxThrottleDevice
+		for _, dev := range devices {
+			if l.IOMaxReadBps > 0 {
+				readBps = append(readBps, specs.LinuxThrottleDevice{LinuxBlockIODevice: dev, Rate: l.IOMaxReadBps})
+			}
+			if l.IOMaxWriteBps > 0 {
+				writeBps = append(writeBps, specs.LinuxThrottleDevice{LinuxBlockIODevice: dev, Rate: l.IOMaxWriteBps})
+			}
+			if l.IOMaxReadIOPS > 0 {
+				readIOPS = append(readIOPS, specs.LinuxThrottleDevice{LinuxBlockIODevice: dev, Rate: l.IOMaxReadIOPS})
+			}
+			if l.IOMaxWriteIOPS > 0 {
+				writeIOPS = append(writeIOPS, specs.LinuxThrottleDevice{LinuxBlockIODevice: dev, Rate: l.IOMaxWriteIOPS})
+			}
+		}
+		blockIO.ThrottleReadBpsDevice = readBps
+		blockIO.ThrottleWriteBpsDevice = writeBps
+		blockIO.ThrottleReadIOPSDevice = readIOPS
+		blockIO.ThrottleWriteIOPSDevice = writeIOPS
+	}
+
+	bndl = bndl.WithBlockIO(blockIO)
 
 	var pids int64
 	if spec.Limits.Pid.Max > math.MaxInt64 {
@@ -78,4 +112,39 @@ func int64PtrVal(n uint64) *int64 {
 	// #nosec G115 - any values over maxint64 are capped above, so no overflow
 	unsignedVal := int64(n)
 	return &unsignedVal
+}
+
+// getAllBlockDevices reads /sys/block and returns major:minor for all real
+// block devices (excludes loop, ram, and dm virtual devices).
+func getAllBlockDevices() []specs.LinuxBlockIODevice {
+	var devices []specs.LinuxBlockIODevice
+	entries, err := os.ReadDir("/sys/block")
+	if err != nil {
+		return devices
+	}
+	for _, e := range entries {
+		name := e.Name()
+		// Skip virtual devices
+		if strings.HasPrefix(name, "loop") || strings.HasPrefix(name, "ram") || strings.HasPrefix(name, "dm-") {
+			continue
+		}
+		data, err := os.ReadFile("/sys/block/" + name + "/dev")
+		if err != nil {
+			continue
+		}
+		parts := strings.SplitN(strings.TrimSpace(string(data)), ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		major, errMaj := strconv.ParseInt(parts[0], 10, 64)
+		minor, errMin := strconv.ParseInt(parts[1], 10, 64)
+		if errMaj != nil || errMin != nil {
+			continue
+		}
+		if major == 0 && minor == 0 {
+			continue
+		}
+		devices = append(devices, specs.LinuxBlockIODevice{Major: major, Minor: minor})
+	}
+	return devices
 }

--- a/rundmc/bundlerules/limits_test.go
+++ b/rundmc/bundlerules/limits_test.go
@@ -193,6 +193,105 @@ var _ = Describe("LimitsRule", func() {
 			}
 		})
 
+		Context("io.max throttling", func() {
+			It("sets ThrottleReadBpsDevice when IOMaxReadBps is configured", func() {
+				limits := bundlerules.Limits{
+					IOMaxReadBps: 59768832,
+				}
+				newBndl, err := limits.Apply(goci.Bundle(), spec.DesiredContainerSpec{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(newBndl.Resources().BlockIO.ThrottleReadBpsDevice).NotTo(BeEmpty())
+				for _, dev := range newBndl.Resources().BlockIO.ThrottleReadBpsDevice {
+					Expect(dev.Rate).To(Equal(uint64(59768832)))
+					Expect(dev.Major).NotTo(Equal(int64(0)))
+				}
+				Expect(newBndl.Resources().BlockIO.ThrottleWriteBpsDevice).To(BeEmpty())
+				Expect(newBndl.Resources().BlockIO.ThrottleReadIOPSDevice).To(BeEmpty())
+				Expect(newBndl.Resources().BlockIO.ThrottleWriteIOPSDevice).To(BeEmpty())
+			})
+
+			It("sets ThrottleWriteBpsDevice when IOMaxWriteBps is configured", func() {
+				limits := bundlerules.Limits{
+					IOMaxWriteBps: 59768832,
+				}
+				newBndl, err := limits.Apply(goci.Bundle(), spec.DesiredContainerSpec{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(newBndl.Resources().BlockIO.ThrottleWriteBpsDevice).NotTo(BeEmpty())
+				for _, dev := range newBndl.Resources().BlockIO.ThrottleWriteBpsDevice {
+					Expect(dev.Rate).To(Equal(uint64(59768832)))
+				}
+				Expect(newBndl.Resources().BlockIO.ThrottleReadBpsDevice).To(BeEmpty())
+			})
+
+			It("sets ThrottleReadIOPSDevice when IOMaxReadIOPS is configured", func() {
+				limits := bundlerules.Limits{
+					IOMaxReadIOPS: 900,
+				}
+				newBndl, err := limits.Apply(goci.Bundle(), spec.DesiredContainerSpec{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(newBndl.Resources().BlockIO.ThrottleReadIOPSDevice).NotTo(BeEmpty())
+				for _, dev := range newBndl.Resources().BlockIO.ThrottleReadIOPSDevice {
+					Expect(dev.Rate).To(Equal(uint64(900)))
+				}
+				Expect(newBndl.Resources().BlockIO.ThrottleWriteIOPSDevice).To(BeEmpty())
+			})
+
+			It("sets ThrottleWriteIOPSDevice when IOMaxWriteIOPS is configured", func() {
+				limits := bundlerules.Limits{
+					IOMaxWriteIOPS: 900,
+				}
+				newBndl, err := limits.Apply(goci.Bundle(), spec.DesiredContainerSpec{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(newBndl.Resources().BlockIO.ThrottleWriteIOPSDevice).NotTo(BeEmpty())
+				for _, dev := range newBndl.Resources().BlockIO.ThrottleWriteIOPSDevice {
+					Expect(dev.Rate).To(Equal(uint64(900)))
+				}
+			})
+
+			It("sets all throttle devices when all io.max values are configured", func() {
+				limits := bundlerules.Limits{
+					IOMaxReadBps:   59768832,
+					IOMaxWriteBps:  59768832,
+					IOMaxReadIOPS:  900,
+					IOMaxWriteIOPS: 900,
+				}
+				newBndl, err := limits.Apply(goci.Bundle(), spec.DesiredContainerSpec{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(newBndl.Resources().BlockIO.ThrottleReadBpsDevice).NotTo(BeEmpty())
+				Expect(newBndl.Resources().BlockIO.ThrottleWriteBpsDevice).NotTo(BeEmpty())
+				Expect(newBndl.Resources().BlockIO.ThrottleReadIOPSDevice).NotTo(BeEmpty())
+				Expect(newBndl.Resources().BlockIO.ThrottleWriteIOPSDevice).NotTo(BeEmpty())
+
+				// All throttle device arrays should have the same length (one entry per real block device)
+				numDevices := len(newBndl.Resources().BlockIO.ThrottleReadBpsDevice)
+				Expect(numDevices).To(BeNumerically(">", 0))
+				Expect(newBndl.Resources().BlockIO.ThrottleWriteBpsDevice).To(HaveLen(numDevices))
+				Expect(newBndl.Resources().BlockIO.ThrottleReadIOPSDevice).To(HaveLen(numDevices))
+				Expect(newBndl.Resources().BlockIO.ThrottleWriteIOPSDevice).To(HaveLen(numDevices))
+			})
+
+			It("does not set any throttle devices when all io.max values are 0", func() {
+				limits := bundlerules.Limits{
+					IOMaxReadBps:   0,
+					IOMaxWriteBps:  0,
+					IOMaxReadIOPS:  0,
+					IOMaxWriteIOPS: 0,
+				}
+				newBndl, err := limits.Apply(goci.Bundle(), spec.DesiredContainerSpec{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(newBndl.Resources().BlockIO.ThrottleReadBpsDevice).To(BeNil())
+				Expect(newBndl.Resources().BlockIO.ThrottleWriteBpsDevice).To(BeNil())
+				Expect(newBndl.Resources().BlockIO.ThrottleReadIOPSDevice).To(BeNil())
+				Expect(newBndl.Resources().BlockIO.ThrottleWriteIOPSDevice).To(BeNil())
+			})
+		})
+
 		Context("when swap limit is disabled", func() {
 			It("does not limit swap in bundle resources", func() {
 				limits := bundlerules.Limits{DisableSwapLimit: true}

--- a/rundmc/bundlerules/limits_test.go
+++ b/rundmc/bundlerules/limits_test.go
@@ -163,6 +163,7 @@ var _ = Describe("LimitsRule", func() {
 			It("sets the CPU shares", func() {
 				newBndl, err := bundlerules.Limits{}.Apply(goci.Bundle(), spec.DesiredContainerSpec{
 					Limits: garden.Limits{
+						//lint:ignore SA1019 - we still specify this to make the deprecated logic work until we get rid of the code in garden
 						CPU: garden.CPULimits{LimitInShares: 1},
 					},
 				})
@@ -176,6 +177,7 @@ var _ = Describe("LimitsRule", func() {
 			It("Weight has precedence ", func() {
 				newBndl, err := bundlerules.Limits{}.Apply(goci.Bundle(), spec.DesiredContainerSpec{
 					Limits: garden.Limits{
+						//lint:ignore SA1019 - we still specify this to make the deprecated logic work until we get rid of the code in garden
 						CPU: garden.CPULimits{LimitInShares: 1, Weight: 2},
 					},
 				})
@@ -385,6 +387,7 @@ var _ = Describe("LimitsRule", func() {
 			It("sets the CPU shares", func() {
 				newBndl, err := bundlerules.Limits{}.Apply(goci.Bundle(), spec.DesiredContainerSpec{
 					Limits: garden.Limits{
+						//lint:ignore SA1019 - we still specify this to make the deprecated logic work until we get rid of the code in garden
 						CPU: garden.CPULimits{LimitInShares: 1},
 					},
 				})
@@ -399,6 +402,7 @@ var _ = Describe("LimitsRule", func() {
 			It("Weight has precedence ", func() {
 				newBndl, err := bundlerules.Limits{}.Apply(goci.Bundle(), spec.DesiredContainerSpec{
 					Limits: garden.Limits{
+						//lint:ignore SA1019 - we still specify this to make the deprecated logic work until we get rid of the code in garden
 						CPU: garden.CPULimits{LimitInShares: 1, Weight: 2},
 					},
 				})

--- a/rundmc/bundlerules/windows_test.go
+++ b/rundmc/bundlerules/windows_test.go
@@ -26,7 +26,8 @@ var _ = Describe("WindowsRule", func() {
 			},
 			Limits: garden.Limits{
 				Memory: garden.MemoryLimits{LimitInBytes: 4096},
-				CPU:    garden.CPULimits{LimitInShares: 321},
+				//lint:ignore SA1019 - we still specify this to make the deprecated logic work until we get rid of the code in garden
+				CPU: garden.CPULimits{LimitInShares: 321},
 			},
 		}
 	})

--- a/rundmc/containerizer.go
+++ b/rundmc/containerizer.go
@@ -384,6 +384,7 @@ func (c *Containerizer) Info(log lager.Logger, handle string) (spec.ActualContai
 		Stopped:    c.states.IsStopped(handle),
 		Limits: garden.Limits{
 			CPU: garden.CPULimits{
+				//lint:ignore SA1019 - we still specify this to make the deprecated logic work until we get rid of the code in garden
 				LimitInShares: cpuShares,
 			},
 			Memory: garden.MemoryLimits{

--- a/rundmc/peas/pea_creator_test.go
+++ b/rundmc/peas/pea_creator_test.go
@@ -298,6 +298,7 @@ var _ = Describe("PeaCreator", func() {
 		Context("when limits are provided", func() {
 			BeforeEach(func() {
 				processSpec.OverrideContainerLimits = &garden.ProcessLimits{
+					//lint:ignore SA1019 - we still specify this to make the deprecated logic work until we get rid of the code in garden
 					CPU:    garden.CPULimits{LimitInShares: 1},
 					Memory: garden.MemoryLimits{LimitInBytes: 2},
 				}


### PR DESCRIPTION
Generated with AI assistance.

- Add IOMaxReadBps/WriteBps/ReadIOPS/WriteIOPS to Limits struct
- Apply throttle on all real block devices when cgroups v2 is active
- getAllBlockDevices() reads /sys/block, filters loop/ram/dm
- New CLI flags: container-io-max-{read,write}-{bps,iops}
- Zero values = disabled (backward compatible)

Companion PR in garden-runc-release: https://github.com/vpetrinski/garden-runc-release/tree/feature/io-max-throttling


- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

  Summary
  ---------------
  Adds per-container disk I/O rate limiting via cgroups v2 `io.max`. When configured, each new container receives IOPS and throughput limits on all real block devices at creation time.

  **Motivation:** A single container can saturate the shared data disk on a Diego cell, starving all other containers of I/O and causing health check timeouts / false app crashes.

  **Changes:**
  - `rundmc/bundlerules/limits.go`: Extended `Limits` struct with `IOMaxReadBps`, `IOMaxWriteBps`, `IOMaxReadIOPS`, `IOMaxWriteIOPS`. When any value > 0 and cgroups v2 is active, applies throttle devices to the OCI
  bundle for all real block devices.
  - `guardiancmd/command.go`: Added 4 new CLI flags (`--container-io-max-{read,write}-{bps,iops}`)
  - `getAllBlockDevices()`: Reads `/sys/block`, filters virtual devices (loop, ram, dm), returns major:minor for real devices.

  **Tested:** Custom dev release deployed on Noble cell (Ubuntu 24.04, cgroups v2). Throttled: 60 MB/s vs Unthrottled: 272 MB/s (4.5× protection). App starts and runs normally with limits active.

  Companion PR in garden-runc-release: https://github.com/cloudfoundry/garden-runc-release/compare/develop...vpetrinski:garden-runc-release:feature/io-max-throttling

  Generated with AI assistance.

  Backward Compatibility
  ---------------
  Breaking Change? **No**

  - All new flags default to 0 (unlimited) — no behavioral change unless operator explicitly sets values > 0
  - On cgroups v1 (Jammy) and Windows: silently skipped via `IsCgroup2UnifiedMode()` check
  - Existing containers and configurations are completely unaffected
  - Feature is opt-in only
